### PR TITLE
Handling expired sessions

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -32,6 +32,7 @@ pub struct ClientConfig {
     pub bind_url: Url,
     pub srv_addr: SocketAddr,
     pub auto_connect: bool,
+    pub session_expiration: Duration,
 }
 
 pub struct ClientBuilder {
@@ -254,6 +255,7 @@ impl ClientBuilder {
             bind_url,
             srv_addr: parse_udp_url(&self.srv_url)?.parse()?,
             auto_connect: self.auto_connect,
+            session_expiration: Duration::from_secs(25),
         });
 
         client.spawn().await?;

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -45,7 +45,7 @@ pub struct ClientBuilder {
 
 #[derive(Clone)]
 pub struct Client {
-    config: Arc<ClientConfig>,
+    pub config: Arc<ClientConfig>,
 
     state: Arc<RwLock<ClientState>>,
     pub sessions: SessionsLayer,

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -265,7 +265,9 @@ impl ClientBuilder {
             bind_url,
             srv_addr: parse_udp_url(&self.srv_url)?.parse()?,
             auto_connect: self.auto_connect,
-            session_expiration: self.session_expiration.unwrap_or(Duration::from_secs(25)),
+            session_expiration: self
+                .session_expiration
+                .unwrap_or_else(|| Duration::from_secs(25)),
         });
 
         client.spawn().await?;

--- a/client/src/dispatch.rs
+++ b/client/src/dispatch.rs
@@ -115,6 +115,10 @@ impl Default for Dispatcher {
 }
 
 impl Dispatcher {
+    pub fn last_seen(&self) -> Instant {
+        self.seen.borrow_mut().clone()
+    }
+
     /// Creates a future to await a `T` (response) packet on
     pub fn response<'a, T: 'static>(
         &self,

--- a/client/src/dispatch.rs
+++ b/client/src/dispatch.rs
@@ -116,7 +116,7 @@ impl Default for Dispatcher {
 
 impl Dispatcher {
     pub fn last_seen(&self) -> Instant {
-        self.seen.borrow_mut().clone()
+        *self.seen.borrow_mut()
     }
 
     /// Creates a future to await a `T` (response) packet on

--- a/client/src/expire.rs
+++ b/client/src/expire.rs
@@ -32,7 +32,7 @@ pub async fn track_sessions_expiration(layer: SessionsLayer) {
             })
             .collect::<Vec<_>>();
 
-        tokio::task::spawn_local(close_sessions(layer.clone(), sessions, expired_idx));
+        close_sessions(layer.clone(), sessions, expired_idx).await;
 
         let first_to_expiring = last_seen.iter().min().cloned().unwrap_or(now) + expiration;
 
@@ -49,7 +49,7 @@ async fn close_sessions(layer: SessionsLayer, sessions: Vec<Arc<Session>>, expir
         let session = sessions[idx].clone();
 
         log::info!(
-            "Closing session {}({}) not responding to ping.",
+            "Closing session {} ({}) not responding to ping.",
             session.id,
             session.remote
         );

--- a/client/src/expire.rs
+++ b/client/src/expire.rs
@@ -5,7 +5,7 @@ use crate::session::Session;
 use crate::session_manager::SessionManager;
 
 pub async fn track_sessions_expiration(layer: SessionManager) {
-    let expiration = layer.config.session_expiration.clone();
+    let expiration = layer.config.session_expiration;
 
     loop {
         log::trace!("Checking, if all sessions are alive. Removing not active sessions.");
@@ -17,7 +17,7 @@ pub async fn track_sessions_expiration(layer: SessionManager) {
         // can last a few seconds especially in case of inactive sessions.
         let ping_futures = sessions
             .iter()
-            .map(|session| session.keep_alive(expiration.clone()))
+            .map(|session| session.keep_alive(expiration))
             .collect::<Vec<_>>();
 
         let last_seen = futures::future::join_all(ping_futures).await;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -4,6 +4,7 @@ mod expire;
 mod registry;
 mod session;
 mod session_layer;
+mod session_start;
 pub mod testing;
 mod virtual_layer;
 

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod client;
 mod dispatch;
+mod expire;
 mod registry;
 mod session;
 mod session_layer;

--- a/client/src/registry.rs
+++ b/client/src/registry.rs
@@ -58,6 +58,18 @@ impl NodesRegistry {
         }
     }
 
+    pub async fn nodes_using_session(&self, session: Arc<Session>) -> Vec<NodeId> {
+        let state = self.state.read().await;
+        state
+            .nodes
+            .iter()
+            .filter_map(|(_, entry)| match entry.session.id == session.id {
+                true => Some(entry.id),
+                false => None,
+            })
+            .collect()
+    }
+
     pub async fn resolve_node(&self, node: NodeId) -> anyhow::Result<NodeEntry> {
         let state = self.state.read().await;
         state.resolve_node(node)

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -1,21 +1,15 @@
-use futures::channel::mpsc;
 use futures::future::LocalBoxFuture;
-use futures::{SinkExt, StreamExt};
-use std::collections::HashMap;
-use std::convert::{TryFrom, TryInto};
+use futures::SinkExt;
+use std::convert::TryInto;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::time::{Duration, Instant};
 
 use crate::dispatch::{Dispatched, Dispatcher};
-use crate::session_layer::SessionsLayer;
 
 use ya_client_model::NodeId;
-use ya_relay_core::challenge::{self, prepare_challenge_response, CHALLENGE_DIFFICULTY};
-use ya_relay_core::error::{BadRequest, InternalError, ServerResult, Unauthorized};
 use ya_relay_core::session::SessionId;
 use ya_relay_core::udp_stream::OutStream;
-use ya_relay_core::utils::parse_node_id;
 use ya_relay_proto::proto::{RequestId, SlotId};
 use ya_relay_proto::{codec, proto};
 
@@ -31,7 +25,7 @@ pub struct Session {
     pub id: SessionId,
 
     sink: OutStream,
-    dispatcher: Dispatcher,
+    pub(crate) dispatcher: Dispatcher,
 }
 
 impl Session {
@@ -200,262 +194,5 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         log::trace!("Dropping Session {} ({}).", self.id, self.remote);
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct StartingSessions {
-    state: Arc<Mutex<StartingSessionsState>>,
-
-    layer: SessionsLayer,
-    sink: OutStream,
-}
-
-#[derive(Default)]
-struct StartingSessionsState {
-    /// Initialization of session started by other peers.
-    incoming_sessions: HashMap<SessionId, mpsc::Sender<(RequestId, proto::request::Session)>>,
-    /// Temporary sessions stored during initialization period.
-    /// After session is established, new struct in SessionsLayer is created
-    /// and this one is removed.
-    tmp_sessions: HashMap<SocketAddr, Arc<Session>>,
-}
-
-impl StartingSessions {
-    pub fn new(layer: SessionsLayer, sink: OutStream) -> StartingSessions {
-        StartingSessions {
-            state: Arc::new(Mutex::new(StartingSessionsState::default())),
-            sink,
-            layer,
-        }
-    }
-
-    pub fn temporary_session(&mut self, addr: SocketAddr) -> Arc<Session> {
-        let session = Session::new(addr, SessionId::generate(), self.sink.clone());
-        self.state
-            .lock()
-            .unwrap()
-            .tmp_sessions
-            .insert(addr, session.clone());
-        session
-    }
-
-    pub fn remove_temporary_session(&mut self, addr: &SocketAddr) {
-        self.state.lock().unwrap().tmp_sessions.remove(addr);
-    }
-
-    pub fn dispatcher(&self, addr: SocketAddr) -> Option<Dispatcher> {
-        self.state
-            .lock()
-            .unwrap()
-            .tmp_sessions
-            .get(&addr)
-            .map(|session| session.dispatcher.clone())
-    }
-
-    pub async fn dispatch_session(
-        self,
-        session_id: Vec<u8>,
-        request_id: RequestId,
-        from: SocketAddr,
-        request: proto::request::Session,
-    ) {
-        // This will be new session.
-        match session_id.is_empty() {
-            true => self.new_session(request_id, from, request).await,
-            false => self
-                .existing_session(session_id, request_id, from, request)
-                .await
-                .map_err(|e| e.into()),
-        }
-        .map_err(|e| log::warn!("{}", e))
-        .ok();
-    }
-
-    pub async fn new_session(
-        self,
-        request_id: RequestId,
-        with: SocketAddr,
-        request: proto::request::Session,
-    ) -> anyhow::Result<()> {
-        let node_id = parse_node_id(&request.node_id)?;
-        let session_id = SessionId::generate();
-        let (sender, receiver) = mpsc::channel(1);
-
-        log::info!(
-            "Node {} ({}) tries to establish p2p session.",
-            node_id,
-            with
-        );
-
-        {
-            self.state
-                .lock()
-                .unwrap()
-                .incoming_sessions
-                .entry(session_id)
-                .or_insert(sender);
-        }
-
-        // TODO: Add timeout for session initialization.
-        tokio::task::spawn_local(async move {
-            if let Err(e) = self
-                .clone()
-                .init_session_handler(with, request_id, session_id, request, receiver)
-                .await
-            {
-                log::warn!(
-                    "Error initializing session {} with node {}. Error: {}",
-                    session_id,
-                    node_id,
-                    e
-                );
-
-                // Establishing session failed.
-                self.layer
-                    .error_response(request_id, session_id.to_vec(), &with, e)
-                    .await;
-                self.cleanup_initialization(&session_id).await;
-            }
-        });
-        Ok(())
-    }
-
-    async fn existing_session(
-        &self,
-        raw_id: Vec<u8>,
-        request_id: RequestId,
-        _from: SocketAddr,
-        request: proto::request::Session,
-    ) -> ServerResult<()> {
-        let id = SessionId::try_from(raw_id.clone())
-            .map_err(|_| Unauthorized::InvalidSessionId(raw_id))?;
-
-        let mut sender = {
-            match {
-                self.state
-                    .lock()
-                    .unwrap()
-                    .incoming_sessions
-                    .get(&id)
-                    .cloned()
-            } {
-                Some(sender) => sender.clone(),
-                None => return Err(Unauthorized::SessionNotFound(id).into()),
-            }
-        };
-
-        Ok(sender
-            .send((request_id, request))
-            .await
-            .map_err(|_| InternalError::Send)?)
-    }
-
-    async fn init_session_handler(
-        mut self,
-        with: SocketAddr,
-        request_id: RequestId,
-        session_id: SessionId,
-        request: proto::request::Session,
-        mut rc: mpsc::Receiver<(RequestId, proto::request::Session)>,
-    ) -> ServerResult<()> {
-        let node_id = parse_node_id(&request.node_id)?;
-
-        let (packet, raw_challenge) = prepare_challenge_response();
-        let challenge = proto::Packet::response(
-            request_id,
-            session_id.to_vec(),
-            proto::StatusCode::Ok,
-            packet,
-        );
-
-        let tmp_session = self.temporary_session(with);
-
-        tmp_session
-            .send(challenge)
-            .await
-            .map_err(|_| InternalError::Send)?;
-
-        log::debug!("Challenge sent to Node: [{}], address: {}", node_id, with);
-
-        // Compute challenge in different thread to avoid blocking runtime.
-        let challenge_handle = self.layer.solve_challenge(request).await;
-
-        if let Some((request_id, session)) = rc.next().await {
-            log::debug!(
-                "Got challenge response from node: [{}], address: {}",
-                node_id,
-                with
-            );
-
-            // Validate the challenge
-            let verification = challenge::verify(
-                &raw_challenge,
-                CHALLENGE_DIFFICULTY,
-                &session.challenge_resp,
-                session.public_key.as_slice(),
-            )
-            .map_err(|e| BadRequest::InvalidChallenge(e.to_string()))?;
-
-            if !verification {
-                return Err(Unauthorized::InvalidChallenge.into());
-            }
-
-            log::debug!(
-                "Challenge from Node: [{}], address: {} verified.",
-                node_id,
-                with
-            );
-
-            let packet = proto::response::Session {
-                challenge_resp: challenge_handle
-                    .await
-                    .map_err(|e| InternalError::Generic(e.to_string()))?,
-                challenge_req: None,
-                public_key: self.layer.config.public_key().await?.bytes().to_vec(),
-            };
-
-            tmp_session
-                .send(proto::Packet::response(
-                    request_id,
-                    session_id.to_vec(),
-                    proto::StatusCode::Ok,
-                    packet,
-                ))
-                .await
-                .map_err(|_| InternalError::Send)?;
-
-            self.layer
-                .add_incoming_session(with, session_id, node_id)
-                .await
-                .map_err(|e| InternalError::Generic(e.to_string()))?;
-
-            log::info!(
-                "Incoming P2P session {} with Node: [{}], address: {} established.",
-                session_id,
-                node_id,
-                with
-            );
-        }
-
-        Ok(())
-    }
-
-    async fn cleanup_initialization(&self, session_id: &SessionId) {
-        let mut state = self.state.lock().unwrap();
-
-        state.incoming_sessions.remove(session_id);
-        let addr =
-            state
-                .tmp_sessions
-                .iter()
-                .find_map(|(_, session)| match session.id == *session_id {
-                    true => Some(session.remote),
-                    false => None,
-                });
-
-        if let Some(addr) = addr {
-            state.tmp_sessions.remove(&addr);
-        }
     }
 }

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -197,6 +197,12 @@ impl Session {
     }
 }
 
+impl Drop for Session {
+    fn drop(&mut self) {
+        log::trace!("Dropping Session {} ({}).", self.id, self.remote);
+    }
+}
+
 #[derive(Clone)]
 pub(crate) struct StartingSessions {
     state: Arc<Mutex<StartingSessionsState>>,

--- a/client/src/session_layer.rs
+++ b/client/src/session_layer.rs
@@ -88,7 +88,7 @@ impl SessionsLayer {
 
         self.sink = Some(sink.clone());
 
-        self.virtual_tcp.spawn(self.config.node_id)?;
+        self.virtual_tcp.spawn(self.config.node_id).await?;
 
         let (abort_dispatcher, abort_dispatcher_reg) = AbortHandle::new_pair();
         let (abort_expiration, abort_expiration_reg) = AbortHandle::new_pair();
@@ -545,6 +545,8 @@ impl SessionsLayer {
                 })
                 .ok();
         }
+
+        self.virtual_tcp.shutdown().await;
         Ok(())
     }
 

--- a/client/src/session_layer.rs
+++ b/client/src/session_layer.rs
@@ -694,7 +694,7 @@ impl Handler for SessionsLayer {
         request: proto::Request,
         from: SocketAddr,
     ) -> LocalBoxFuture<()> {
-        log::debug!("Received request packet from {}: {:?}", from, request);
+        log::trace!("Received request packet from {}: {:?}", from, request);
 
         let (request_id, kind) = match request {
             proto::Request {

--- a/client/src/session_manager.rs
+++ b/client/src/session_manager.rs
@@ -526,7 +526,7 @@ impl SessionManager {
         );
         {
             let starting_session = { self.state.read().await.starting_sessions.clone() }
-                .ok_or(anyhow!("Starting sessions not loaded yet"))?;
+                .ok_or_else(|| anyhow!("Starting sessions not loaded yet"))?;
             let wait_for_tmp = starting_session.register_waiting_for_node(node_id);
             {
                 let server_session = self.server_session().await?;

--- a/client/src/session_start.rs
+++ b/client/src/session_start.rs
@@ -1,0 +1,296 @@
+use futures::channel::mpsc;
+use futures::future::{AbortHandle, Abortable};
+use futures::{SinkExt, StreamExt};
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use ya_relay_core::challenge::{self, prepare_challenge_response, CHALLENGE_DIFFICULTY};
+use ya_relay_core::error::{BadRequest, InternalError, ServerResult, Unauthorized};
+use ya_relay_core::session::SessionId;
+use ya_relay_core::udp_stream::OutStream;
+use ya_relay_core::utils::parse_node_id;
+use ya_relay_proto::proto;
+use ya_relay_proto::proto::RequestId;
+
+use crate::dispatch::Dispatcher;
+use crate::session::Session;
+use crate::session_layer::SessionsLayer;
+
+#[derive(Clone)]
+pub(crate) struct StartingSessions {
+    state: Arc<Mutex<StartingSessionsState>>,
+
+    layer: SessionsLayer,
+    sink: OutStream,
+}
+
+#[derive(Default)]
+struct StartingSessionsState {
+    /// Initialization of session started by other peers.
+    incoming_sessions: HashMap<SessionId, mpsc::Sender<(RequestId, proto::request::Session)>>,
+    /// Temporary sessions stored during initialization period.
+    /// After session is established, new struct in SessionsLayer is created
+    /// and this one is removed.
+    tmp_sessions: HashMap<SocketAddr, Arc<Session>>,
+
+    /// Collection of background tasks that must be stopped on shutdown.
+    handles: Vec<AbortHandle>,
+}
+
+impl StartingSessions {
+    pub fn new(layer: SessionsLayer, sink: OutStream) -> StartingSessions {
+        StartingSessions {
+            state: Arc::new(Mutex::new(StartingSessionsState::default())),
+            sink,
+            layer,
+        }
+    }
+
+    pub fn temporary_session(&mut self, addr: SocketAddr) -> Arc<Session> {
+        let session = Session::new(addr, SessionId::generate(), self.sink.clone());
+        self.state
+            .lock()
+            .unwrap()
+            .tmp_sessions
+            .insert(addr, session.clone());
+        session
+    }
+
+    pub fn remove_temporary_session(&mut self, addr: &SocketAddr) {
+        self.state.lock().unwrap().tmp_sessions.remove(addr);
+    }
+
+    pub fn dispatcher(&self, addr: SocketAddr) -> Option<Dispatcher> {
+        self.state
+            .lock()
+            .unwrap()
+            .tmp_sessions
+            .get(&addr)
+            .map(|session| session.dispatcher.clone())
+    }
+
+    pub async fn dispatch_session(
+        self,
+        session_id: Vec<u8>,
+        request_id: RequestId,
+        from: SocketAddr,
+        request: proto::request::Session,
+    ) {
+        // This will be new session.
+        match session_id.is_empty() {
+            true => self.new_session(request_id, from, request).await,
+            false => self
+                .existing_session(session_id, request_id, from, request)
+                .await
+                .map_err(|e| e.into()),
+        }
+        .map_err(|e| log::warn!("{}", e))
+        .ok();
+    }
+
+    pub async fn new_session(
+        self,
+        request_id: RequestId,
+        with: SocketAddr,
+        request: proto::request::Session,
+    ) -> anyhow::Result<()> {
+        let node_id = parse_node_id(&request.node_id)?;
+        let session_id = SessionId::generate();
+        let (sender, receiver) = mpsc::channel(1);
+
+        log::info!(
+            "Node {} ({}) tries to establish p2p session.",
+            node_id,
+            with
+        );
+
+        let (abort_handle, abort_registration) = AbortHandle::new_pair();
+
+        // TODO: Add timeout for session initialization.
+        let myself = self.clone();
+        let init_future = Abortable::new(
+            async move {
+                if let Err(e) = self
+                    .clone()
+                    .init_session_handler(with, request_id, session_id, request, receiver)
+                    .await
+                {
+                    log::warn!(
+                        "Error initializing session {} with node {}. Error: {}",
+                        session_id,
+                        node_id,
+                        e
+                    );
+
+                    // Establishing session failed.
+                    self.layer
+                        .error_response(request_id, session_id.to_vec(), &with, e)
+                        .await;
+                    self.cleanup_initialization(&session_id).await;
+                }
+            },
+            abort_registration,
+        );
+
+        {
+            let mut state = myself.state.lock().unwrap();
+
+            state.incoming_sessions.entry(session_id).or_insert(sender);
+            state.handles.push(abort_handle);
+        }
+
+        tokio::task::spawn_local(init_future);
+        Ok(())
+    }
+
+    async fn existing_session(
+        &self,
+        raw_id: Vec<u8>,
+        request_id: RequestId,
+        _from: SocketAddr,
+        request: proto::request::Session,
+    ) -> ServerResult<()> {
+        let id = SessionId::try_from(raw_id.clone())
+            .map_err(|_| Unauthorized::InvalidSessionId(raw_id))?;
+
+        let mut sender = {
+            match {
+                self.state
+                    .lock()
+                    .unwrap()
+                    .incoming_sessions
+                    .get(&id)
+                    .cloned()
+            } {
+                Some(sender) => sender.clone(),
+                None => return Err(Unauthorized::SessionNotFound(id).into()),
+            }
+        };
+
+        Ok(sender
+            .send((request_id, request))
+            .await
+            .map_err(|_| InternalError::Send)?)
+    }
+
+    async fn init_session_handler(
+        mut self,
+        with: SocketAddr,
+        request_id: RequestId,
+        session_id: SessionId,
+        request: proto::request::Session,
+        mut rc: mpsc::Receiver<(RequestId, proto::request::Session)>,
+    ) -> ServerResult<()> {
+        let node_id = parse_node_id(&request.node_id)?;
+
+        let (packet, raw_challenge) = prepare_challenge_response();
+        let challenge = proto::Packet::response(
+            request_id,
+            session_id.to_vec(),
+            proto::StatusCode::Ok,
+            packet,
+        );
+
+        let tmp_session = self.temporary_session(with);
+
+        tmp_session
+            .send(challenge)
+            .await
+            .map_err(|_| InternalError::Send)?;
+
+        log::debug!("Challenge sent to Node: [{}], address: {}", node_id, with);
+
+        // Compute challenge in different thread to avoid blocking runtime.
+        let challenge_handle = self.layer.solve_challenge(request).await;
+
+        if let Some((request_id, session)) = rc.next().await {
+            log::debug!(
+                "Got challenge response from node: [{}], address: {}",
+                node_id,
+                with
+            );
+
+            // Validate the challenge
+            let verification = challenge::verify(
+                &raw_challenge,
+                CHALLENGE_DIFFICULTY,
+                &session.challenge_resp,
+                session.public_key.as_slice(),
+            )
+            .map_err(|e| BadRequest::InvalidChallenge(e.to_string()))?;
+
+            if !verification {
+                return Err(Unauthorized::InvalidChallenge.into());
+            }
+
+            log::debug!(
+                "Challenge from Node: [{}], address: {} verified.",
+                node_id,
+                with
+            );
+
+            let packet = proto::response::Session {
+                challenge_resp: challenge_handle
+                    .await
+                    .map_err(|e| InternalError::Generic(e.to_string()))?,
+                challenge_req: None,
+                public_key: self.layer.config.public_key().await?.bytes().to_vec(),
+            };
+
+            tmp_session
+                .send(proto::Packet::response(
+                    request_id,
+                    session_id.to_vec(),
+                    proto::StatusCode::Ok,
+                    packet,
+                ))
+                .await
+                .map_err(|_| InternalError::Send)?;
+
+            self.layer
+                .add_incoming_session(with, session_id, node_id)
+                .await
+                .map_err(|e| InternalError::Generic(e.to_string()))?;
+
+            log::info!(
+                "Incoming P2P session {} with Node: [{}], address: {} established.",
+                session_id,
+                node_id,
+                with
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn cleanup_initialization(&self, session_id: &SessionId) {
+        let mut state = self.state.lock().unwrap();
+
+        state.incoming_sessions.remove(session_id);
+        let addr =
+            state
+                .tmp_sessions
+                .iter()
+                .find_map(|(_, session)| match session.id == *session_id {
+                    true => Some(session.remote),
+                    false => None,
+                });
+
+        if let Some(addr) = addr {
+            state.tmp_sessions.remove(&addr);
+        }
+    }
+
+    pub async fn shutdown(&self) {
+        let mut state = self.state.lock().unwrap();
+
+        for handle in &state.handles {
+            handle.abort();
+        }
+
+        state.incoming_sessions.clear();
+        state.tmp_sessions.clear();
+    }
+}

--- a/client/src/session_start.rs
+++ b/client/src/session_start.rs
@@ -101,7 +101,7 @@ impl StartingSessions {
         let (sender, receiver) = mpsc::channel(1);
 
         log::info!(
-            "Node {} ({}) tries to establish p2p session.",
+            "Node [{}] ({}) tries to establish p2p session.",
             node_id,
             with
         );

--- a/client/src/testing.rs
+++ b/client/src/testing.rs
@@ -1,1 +1,3 @@
+pub mod forwarding_utils;
+
 pub use crate::session::Session;

--- a/client/src/testing/forwarding_utils.rs
+++ b/client/src/testing/forwarding_utils.rs
@@ -40,6 +40,8 @@ pub async fn spawn_receive_for_client(
     client: &Client,
     label: &'static str,
 ) -> anyhow::Result<Rc<AtomicBool>> {
+    println!("{}: [{}]", label, client.node_id());
+
     let received = Rc::new(AtomicBool::new(false));
     let rx = client
         .forward_receiver()

--- a/client/src/testing/forwarding_utils.rs
+++ b/client/src/testing/forwarding_utils.rs
@@ -22,7 +22,7 @@ pub fn spawn_receive<T: std::fmt::Debug + 'static>(
     println!("Spawning {} receiver", label);
 
     tokio::task::spawn_local({
-        let received = received.clone();
+        let received = received;
         async move {
             rx.for_each(|item| {
                 let received = received.clone();

--- a/client/src/testing/forwarding_utils.rs
+++ b/client/src/testing/forwarding_utils.rs
@@ -1,0 +1,73 @@
+use anyhow::{bail, Context};
+use futures::{SinkExt, StreamExt};
+use std::rc::Rc;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering::SeqCst;
+use std::time::Duration;
+use tokio::sync::mpsc;
+
+use crate::client::ForwardSender;
+use crate::Client;
+
+pub fn spawn_receive<T: std::fmt::Debug + 'static>(
+    label: &'static str,
+    received: Rc<AtomicBool>,
+    rx: mpsc::UnboundedReceiver<T>,
+) {
+    println!("Spawning {} receiver", label);
+
+    tokio::task::spawn_local({
+        let received = received.clone();
+        async move {
+            rx.for_each(|item| {
+                let received = received.clone();
+                async move {
+                    println!("{} received {:?}", label, item);
+                    received.clone().store(true, SeqCst)
+                }
+            })
+            .await;
+        }
+    });
+}
+
+pub async fn spawn_receive_for_client(
+    client: &Client,
+    label: &'static str,
+) -> anyhow::Result<Rc<AtomicBool>> {
+    let received = Rc::new(AtomicBool::new(false));
+    let rx = client
+        .forward_receiver()
+        .await
+        .context("no forward receiver")?;
+
+    spawn_receive(label, received.clone(), rx);
+
+    Ok(received)
+}
+
+/// Assign result to variable if you want to keep TCP connection alive.
+pub async fn check_forwarding(
+    sender_client: &Client,
+    receiver_client: &Client,
+    received: Rc<AtomicBool>,
+) -> anyhow::Result<ForwardSender> {
+    let mut tx = sender_client.forward(receiver_client.node_id()).await?;
+
+    println!(
+        "Sending forward packets to [{}].",
+        receiver_client.node_id()
+    );
+
+    tx.send(vec![1u8]).await?;
+
+    tokio::time::delay_for(Duration::from_millis(100)).await;
+
+    if !received.load(SeqCst) {
+        bail!("Data not received.")
+    }
+
+    // Clear receiver for further usage.
+    received.store(false, SeqCst);
+    Ok(tx)
+}

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -132,6 +132,12 @@ impl TcpLayer {
         &self,
         node: NodeEntry,
     ) -> anyhow::Result<(ForwardSender, oneshot::Receiver<()>)> {
+        log::debug!(
+            "[VirtualTcp] Connecting to node [{}] using session {}.",
+            node.id,
+            node.session.id
+        );
+
         // This will override previous Node settings, if we had them.
         let node = self.add_virt_node(node).await?;
         let connection = self.net.connect(node.endpoint, TCP_CONN_TIMEOUT).await?;
@@ -172,7 +178,7 @@ impl TcpLayer {
             rx.close();
 
             log::debug!(
-                "Virtual Tcp: disconnected from relay: {}. Stopping forwarding to Node [{}].",
+                "Virtual Tcp: disconnected from: {}. Stopping forwarding to Node [{}].",
                 node.session.remote,
                 node.id,
             );

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -15,7 +15,7 @@ use ya_relay_core::crypto::PublicKey;
 use ya_relay_core::utils::parse_node_id;
 
 use ya_relay_proto::proto::{Forward, Payload, SlotId};
-use ya_relay_stack::interface::{add_iface_address, add_iface_route, default_iface};
+use ya_relay_stack::interface::{add_iface_address, add_iface_route, default_iface, to_mac};
 use ya_relay_stack::smoltcp::iface::Route;
 use ya_relay_stack::smoltcp::wire::{IpAddress, IpCidr, IpEndpoint};
 use ya_relay_stack::socket::{SocketEndpoint, TCP_CONN_TIMEOUT};
@@ -187,7 +187,6 @@ impl TcpLayer {
             }
 
             myself.net.close_connection(&connection.meta);
-            myself.net.poll();
 
             // Cleanup all internal info about Node.
             myself
@@ -442,7 +441,7 @@ fn default_network(key: PublicKey) -> Network {
     let address = key.address();
     let ipv6_addr = to_ipv6(address);
     let ipv6_cidr = IpCidr::new(IpAddress::from(ipv6_addr), IPV6_DEFAULT_CIDR);
-    let mut iface = default_iface();
+    let mut iface = default_iface(to_mac(&address[..6]));
 
     let name = format!(
         "{:02x}{:02x}{:02x}{:02x}",

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -6,7 +6,6 @@ use futures::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::RwLock;
 

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -6,6 +6,7 @@ use futures::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::net::Ipv6Addr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::sync::RwLock;
 
@@ -186,6 +187,7 @@ impl TcpLayer {
             }
 
             myself.net.close_connection(&connection.meta);
+            myself.net.poll();
 
             // Cleanup all internal info about Node.
             myself
@@ -231,9 +233,9 @@ impl TcpLayer {
 
     pub async fn shutdown(&self) {
         let mut state = self.state.write().await;
-        for handle in &state.handles {
-            handle.abort();
-        }
+        // for handle in &state.handles {
+        //     handle.abort();
+        // }
 
         for (_, mut sender) in state.forward_senders.drain() {
             sender.close().await.ok();

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -171,10 +171,10 @@ impl TcpLayer {
             disconnect_tx.send(()).ok();
             rx.close();
 
-            log::trace!(
-                "[{}] forward: disconnected from server: {}",
-                id,
-                node.session.remote
+            log::debug!(
+                "Virtual Tcp: disconnected from relay: {}. Stopping forwarding to Node [{}].",
+                node.session.remote,
+                node.id,
             );
         });
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,11 +8,8 @@ pub mod utils;
 
 pub use ya_client_model::NodeId;
 
-use std::time::Duration;
 use utils::typed_from_env;
 
 lazy_static::lazy_static! {
     pub static ref DEFAULT_NET_PORT: u16 = typed_from_env::<u16>("DEFAULT_NET_PORT", 7464);
-    pub static ref FORWARDER_RATE_LIMIT: u32 = typed_from_env::<u32>("FORWARDER_RATE_LIMIT", 2048);
-    pub static ref FORWARDER_RESUME_INTERVAL: Duration = Duration::new(typed_from_env::<u64>("FORWARDER_RESUME_INTERVAL",1), 0); // seconds
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,8 +13,6 @@ use utils::typed_from_env;
 
 lazy_static::lazy_static! {
     pub static ref DEFAULT_NET_PORT: u16 = typed_from_env::<u16>("DEFAULT_NET_PORT", 7464);
-    pub static ref SESSION_CLEANER_INTERVAL: Duration = Duration::new(typed_from_env::<u64>("SESSION_CLEANER_INTERVAL", 10), 0); // seconds
-    pub static ref SESSION_TIMEOUT: i64 = typed_from_env::<i64>("SESSION_TIMEOUT", 60); // seconds
     pub static ref FORWARDER_RATE_LIMIT: u32 = typed_from_env::<u32>("FORWARDER_RATE_LIMIT", 2048);
     pub static ref FORWARDER_RESUME_INTERVAL: Duration = Duration::new(typed_from_env::<u64>("FORWARDER_RESUME_INTERVAL",1), 0); // seconds
 }

--- a/crates/proto/protobuf/ya_relay.proto
+++ b/crates/proto/protobuf/ya_relay.proto
@@ -187,6 +187,7 @@ message Control {
         PauseForwarding pause_forwarding = 20;
         ResumeForwarding resume_forwarding = 21;
         StopForwarding stop_forwarding = 22;
+        Disconnected disconnected = 23;
     }
 
     /* Connect to another node */
@@ -206,6 +207,11 @@ message Control {
     message StopForwarding {
         uint32 slot = 1;
         StatusCode code = 3;
+    }
+
+    /* Node disconnected. Receiver of this message should stop forwarding */
+    message Disconnected {
+        uint32 slot = 1;
     }
 }
 

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -364,3 +364,4 @@ impl_convert_kind!(control, ReverseConnection);
 impl_convert_kind!(control, PauseForwarding);
 impl_convert_kind!(control, ResumeForwarding);
 impl_convert_kind!(control, StopForwarding);
+impl_convert_kind!(control, Disconnected);

--- a/crates/stack/src/connection.rs
+++ b/crates/stack/src/connection.rs
@@ -148,6 +148,7 @@ pub struct Send<'a> {
     offset: usize,
     connection: Connection,
     sockets: Rc<RefCell<SocketSet<'a>>>,
+    /// Send completion callback; there may as well have been no data sent
     sent: Box<dyn Fn()>,
 }
 

--- a/crates/stack/src/interface.rs
+++ b/crates/stack/src/interface.rs
@@ -50,13 +50,13 @@ pub fn add_iface_route(iface: &mut CaptureInterface, net_ip: IpCidr, route: Rout
 
 pub fn to_mac(mac: &[u8]) -> EthernetAddress {
     let mut ethernet = if mac.len() == 6 {
-        EthernetAddress::from_bytes(&mac)
+        EthernetAddress::from_bytes(mac)
     } else {
         EthernetAddress::from_bytes(&rand::random::<[u8; 6]>())
     };
 
     if !ethernet.is_unicast() {
-        ethernet.0[0] = ethernet.0[0] & !0x01;
+        ethernet.0[0] = !0x01;
     }
 
     ethernet

--- a/crates/stack/src/interface.rs
+++ b/crates/stack/src/interface.rs
@@ -2,27 +2,20 @@ use std::collections::BTreeMap;
 
 use managed::{ManagedMap, ManagedSlice};
 use smoltcp::iface::{EthernetInterface, EthernetInterfaceBuilder, NeighborCache, Route, Routes};
-use smoltcp::wire::{EthernetAddress, IpCidr};
+use smoltcp::wire::{EthernetAddress, IpAddress, IpCidr};
 
 use crate::device::CaptureDevice;
 
 pub type CaptureInterface<'a> = EthernetInterface<'a, CaptureDevice>;
 
 /// Creates a default network interface
-pub fn default_iface<'a>() -> CaptureInterface<'a> {
+pub fn default_iface<'a>(mac: EthernetAddress) -> CaptureInterface<'a> {
     let neighbor_cache = NeighborCache::new(BTreeMap::new());
     let routes = Routes::new(BTreeMap::new());
     let addrs = Vec::new();
 
-    let ethernet_addr = loop {
-        let addr = EthernetAddress(rand::random());
-        if addr.is_unicast() {
-            break addr;
-        }
-    };
-
     EthernetInterfaceBuilder::new(CaptureDevice::default())
-        .ethernet_addr(ethernet_addr)
+        .ethernet_addr(mac)
         .neighbor_cache(neighbor_cache)
         .ip_addrs(addrs)
         .routes(routes)
@@ -53,4 +46,26 @@ pub fn add_iface_route(iface: &mut CaptureInterface, net_ip: IpCidr, route: Rout
             *routes = map.into();
         }
     });
+}
+
+pub fn to_mac(mac: &[u8]) -> EthernetAddress {
+    let mut ethernet = if mac.len() == 6 {
+        EthernetAddress::from_bytes(&mac)
+    } else {
+        EthernetAddress::from_bytes(&rand::random::<[u8; 6]>())
+    };
+
+    if !ethernet.is_unicast() {
+        ethernet.0[0] = ethernet.0[0] & !0x01;
+    }
+
+    ethernet
+}
+
+pub fn ip_to_mac(ip: IpAddress) -> EthernetAddress {
+    match ip {
+        IpAddress::Ipv4(ip) => to_mac(ip.as_bytes()),
+        IpAddress::Ipv6(ip) => to_mac(ip.as_bytes()),
+        _ => to_mac(&rand::random::<[u8; 6]>()),
+    }
 }

--- a/crates/stack/src/network.rs
+++ b/crates/stack/src/network.rs
@@ -568,7 +568,7 @@ mod tests {
     use smoltcp::wire::{IpAddress, IpCidr, Ipv4Address};
     use tokio::task::spawn_local;
 
-    use crate::interface::{add_iface_address, add_iface_route, default_iface};
+    use crate::interface::{add_iface_address, add_iface_route, default_iface, ip_to_mac};
     use crate::{Connection, IngressEvent, Network, Protocol, Stack};
 
     const EXCHANGE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -581,7 +581,7 @@ mod tests {
             _ => panic!("unspecified address"),
         };
 
-        let mut iface = default_iface();
+        let mut iface = default_iface(ip_to_mac(ip));
         add_iface_address(&mut iface, ipv4_cidr);
         add_iface_route(&mut iface, ipv4_cidr, route);
         Network::new(ip.to_string(), Stack::with(iface))

--- a/crates/stack/src/network.rs
+++ b/crates/stack/src/network.rs
@@ -127,7 +127,7 @@ impl Network {
             .insert(connection.into(), connection);
     }
 
-    fn close_connection(&self, meta: &ConnectionMeta) -> Option<Connection> {
+    pub fn close_connection(&self, meta: &ConnectionMeta) -> Option<Connection> {
         { self.connections.borrow_mut().remove(meta) }.map(|connection| {
             self.stack
                 .close(connection.meta.protocol, connection.handle);

--- a/crates/stack/src/stack.rs
+++ b/crates/stack/src/stack.rs
@@ -161,7 +161,11 @@ impl<'a> Stack<'a> {
         let mut ports = self.ports.borrow_mut();
 
         let endpoint = match protocol {
-            Protocol::Tcp => sockets.get::<TcpSocket>(handle).local_endpoint(),
+            Protocol::Tcp => {
+                let mut socket = sockets.get::<TcpSocket>(handle);
+                socket.close();
+                socket.local_endpoint()
+            }
             Protocol::Udp => sockets.get::<UdpSocket>(handle).endpoint(),
             _ => return,
         };

--- a/crates/stack/src/stack.rs
+++ b/crates/stack/src/stack.rs
@@ -23,7 +23,7 @@ pub struct Stack<'a> {
 impl<'a> Stack<'a> {
     pub fn new(net_ip: IpCidr, net_route: Route) -> Self {
         let sockets = SocketSet::new(Vec::with_capacity(8));
-        let mut iface = default_iface();
+        let mut iface = default_iface(ip_to_mac(net_ip.address()));
         add_iface_route(&mut iface, net_ip, net_route);
 
         Self {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,6 +27,7 @@ dotenv = "0.15"
 env_logger = { version = "0.8", default-features = false }
 futures = "0.3"
 governor = "0.3.2"
+humantime = "2.1"
 itertools = "0.10.1"
 log = "0.4"
 rand = { version = "0.8", features = ["std"] }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -1,3 +1,4 @@
+use std::time::Duration;
 use structopt::{clap, StructOpt};
 
 #[derive(StructOpt)]
@@ -8,4 +9,8 @@ pub struct Config {
     pub address: url::Url,
     #[structopt(long, env = "NET_IP_CHECKER_PORT")]
     pub ip_checker_port: u16,
+    #[structopt(long, env, parse(try_from_str = humantime::parse_duration), default_value = "10s")]
+    pub session_cleaner_interval: Duration,
+    #[structopt(long, env, default_value = "60")]
+    pub session_timeout: i64,
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -13,4 +13,8 @@ pub struct Config {
     pub session_cleaner_interval: Duration,
     #[structopt(long, env, default_value = "60")]
     pub session_timeout: i64,
+    #[structopt(long, env, default_value = "1073741824")]
+    pub forwarder_rate_limit: u32,
+    #[structopt(long, env, parse(try_from_str = humantime::parse_duration), default_value = "1s")]
+    pub forwarder_resume_interval: Duration,
 }

--- a/server/src/public_endpoints.rs
+++ b/server/src/public_endpoints.rs
@@ -26,7 +26,7 @@ pub struct EndpointsCheckerState {
 }
 
 impl EndpointsChecker {
-    pub async fn spawn(config: Config) -> anyhow::Result<EndpointsChecker> {
+    pub async fn spawn(config: Arc<Config>) -> anyhow::Result<EndpointsChecker> {
         // Spawn new socket only for discovering IPs on the same address, but different port.
         let mut address = config.address.clone();
         address

--- a/server/src/testing/server.rs
+++ b/server/src/testing/server.rs
@@ -3,6 +3,7 @@ use chrono::Local;
 use futures::future::{AbortHandle, Abortable};
 use futures::FutureExt;
 use std::io::Write;
+use std::time::Duration;
 use url::Url;
 
 use crate::server::Server;
@@ -38,6 +39,8 @@ pub async fn init_test_server() -> anyhow::Result<ServerWrapper> {
     let server = Server::bind_udp(Config {
         address: Url::parse("udp://127.0.0.1:0")?,
         ip_checker_port: 0,
+        session_cleaner_interval: Duration::from_secs(60),
+        session_timeout: 10,
     })
     .await?;
 

--- a/server/src/testing/server.rs
+++ b/server/src/testing/server.rs
@@ -41,6 +41,8 @@ pub async fn init_test_server() -> anyhow::Result<ServerWrapper> {
         ip_checker_port: 0,
         session_cleaner_interval: Duration::from_secs(60),
         session_timeout: 10,
+        forwarder_rate_limit: 2048,
+        forwarder_resume_interval: Duration::from_secs(1),
     })
     .await?;
 

--- a/server/tests/test_expired_session.rs
+++ b/server/tests/test_expired_session.rs
@@ -1,0 +1,61 @@
+use std::time::Duration;
+use url::Url;
+
+use ya_relay_client::testing::forwarding_utils::{check_forwarding, spawn_receive_for_client};
+use ya_relay_client::ClientBuilder;
+use ya_relay_server::testing::server::init_test_server;
+
+#[serial_test::serial]
+async fn test_restarting_p2p_session() -> anyhow::Result<()> {
+    let wrapper = init_test_server().await?;
+
+    let client1 = ClientBuilder::from_url(wrapper.url())
+        .connect()
+        .expire_session_after(Duration::from_secs(2))
+        .build()
+        .await?;
+    let mut client2 = ClientBuilder::from_url(wrapper.url())
+        .connect()
+        .expire_session_after(Duration::from_secs(2))
+        .build()
+        .await?;
+
+    let addr2 = client2.bind_addr().await?;
+
+    let marker1 = spawn_receive_for_client(&client1, "Client1").await?;
+    let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
+
+    let _keep1 = check_forwarding(&client1, &client2, marker2.clone())
+        .await
+        .unwrap();
+
+    let _keep2 = check_forwarding(&client2, &client1, marker1.clone())
+        .await
+        .unwrap();
+
+    // Restart client.
+    client2.shutdown().await.unwrap();
+    drop(_keep2);
+
+    tokio::time::delay_for(Duration::from_secs(3)).await;
+
+    // Start client on the same port as previously.
+    let client2 = ClientBuilder::from_url(wrapper.url())
+        .listen(Url::parse(&format!("udp://{}:{}", addr2.ip(), addr2.port())).unwrap())
+        .connect()
+        .expire_session_after(Duration::from_secs(2))
+        .build()
+        .await?;
+
+    let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
+
+    let _keep = check_forwarding(&client1, &client2, marker2.clone())
+        .await
+        .unwrap();
+
+    let _keep = check_forwarding(&client2, &client1, marker1.clone())
+        .await
+        .unwrap();
+
+    Ok(())
+}

--- a/server/tests/test_expired_session.rs
+++ b/server/tests/test_expired_session.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 use url::Url;
 
-use ya_relay_client::testing::forwarding_utils::{check_forwarding, spawn_receive_for_client};
+use ya_relay_client::testing::forwarding_utils::{
+    check_forwarding, spawn_receive_for_client, Mode,
+};
 use ya_relay_client::ClientBuilder;
 use ya_relay_server::testing::server::init_test_server;
 
@@ -23,11 +25,11 @@ async fn test_restarting_p2p_session() -> anyhow::Result<()> {
     let marker1 = spawn_receive_for_client(&client1, "Client1").await?;
     let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
 
-    let _keep1 = check_forwarding(&client1, &client2, marker2.clone())
+    let _keep1 = check_forwarding(&client1, &client2, marker2.clone(), Mode::Reliable)
         .await
         .unwrap();
 
-    let _keep2 = check_forwarding(&client2, &client1, marker1.clone())
+    let _keep2 = check_forwarding(&client2, &client1, marker1.clone(), Mode::Reliable)
         .await
         .unwrap();
 
@@ -41,7 +43,8 @@ async fn test_restarting_p2p_session() -> anyhow::Result<()> {
 
     println!("Waiting for session cleanup.");
 
-    tokio::time::delay_for(Duration::from_secs(5)).await;
+    // Wait expiration timeout + ping timeout + 1s margin
+    tokio::time::delay_for(Duration::from_secs(6)).await;
 
     println!("Starting Client2");
 
@@ -56,11 +59,105 @@ async fn test_restarting_p2p_session() -> anyhow::Result<()> {
 
     let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
 
-    let _keep = check_forwarding(&client1, &client2, marker2.clone())
+    let _keep = check_forwarding(&client2, &client1, marker1.clone(), Mode::Reliable)
         .await
         .unwrap();
 
-    let _keep = check_forwarding(&client2, &client1, marker1.clone())
+    let _keep = check_forwarding(&client1, &client2, marker2.clone(), Mode::Reliable)
+        .await
+        .unwrap();
+
+    Ok(())
+}
+
+#[serial_test::serial]
+async fn test_restarting_p2p_session_unreliable() -> anyhow::Result<()> {
+    let wrapper = init_test_server().await?;
+
+    let client1 = ClientBuilder::from_url(wrapper.url())
+        .connect()
+        .expire_session_after(Duration::from_secs(2))
+        .build()
+        .await?;
+    let mut client2 = ClientBuilder::from_url(wrapper.url())
+        .connect()
+        .expire_session_after(Duration::from_secs(2))
+        .build()
+        .await?;
+
+    let marker1 = spawn_receive_for_client(&client1, "Client1").await?;
+    let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
+
+    let _keep1 = check_forwarding(&client1, &client2, marker2.clone(), Mode::Unreliable)
+        .await
+        .unwrap();
+
+    let _keep2 = check_forwarding(&client2, &client1, marker1.clone(), Mode::Unreliable)
+        .await
+        .unwrap();
+
+    println!("Shutting down Client2");
+
+    let addr2 = client2.bind_addr().await?;
+    let crypto = client2.config.crypto.clone();
+
+    client2.shutdown().await.unwrap();
+    drop(_keep2);
+
+    println!("Waiting for session cleanup.");
+
+    // Wait expiration timeout + ping timeout + 1s margin
+    tokio::time::delay_for(Duration::from_secs(6)).await;
+
+    println!("Starting Client2");
+
+    // Start client on the same port as previously.
+    let mut client2 = ClientBuilder::from_url(wrapper.url())
+        .listen(Url::parse(&format!("udp://{}:{}", addr2.ip(), addr2.port())).unwrap())
+        .crypto(crypto.clone())
+        .connect()
+        .expire_session_after(Duration::from_secs(2))
+        .build()
+        .await?;
+
+    let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
+
+    let _keep1 = check_forwarding(&client2, &client1, marker1.clone(), Mode::Unreliable)
+        .await
+        .unwrap();
+
+    let _keep2 = check_forwarding(&client1, &client2, marker2.clone(), Mode::Unreliable)
+        .await
+        .unwrap();
+
+    // Disconnect Client2 again and this time connect from client1 to client2 first.
+    println!("Shutting down Client2 for the second time");
+
+    client2.shutdown().await.unwrap();
+    drop(_keep1);
+
+    println!("Waiting for session cleanup.");
+
+    // Wait expiration timeout + ping timeout + 1s margin
+    tokio::time::delay_for(Duration::from_secs(6)).await;
+
+    println!("Starting Client2");
+
+    // Start client on the same port as previously.
+    let client2 = ClientBuilder::from_url(wrapper.url())
+        .listen(Url::parse(&format!("udp://{}:{}", addr2.ip(), addr2.port())).unwrap())
+        .crypto(crypto.clone())
+        .connect()
+        .expire_session_after(Duration::from_secs(2))
+        .build()
+        .await?;
+
+    let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
+
+    let _keep = check_forwarding(&client1, &client2, marker2.clone(), Mode::Unreliable)
+        .await
+        .unwrap();
+    let _keep = check_forwarding(&client2, &client1, marker1.clone(), Mode::Unreliable)
         .await
         .unwrap();
 

--- a/server/tests/test_expired_session.rs
+++ b/server/tests/test_expired_session.rs
@@ -8,7 +8,7 @@ use ya_relay_client::ClientBuilder;
 use ya_relay_server::testing::server::init_test_server;
 
 #[serial_test::serial]
-async fn test_restarting_p2p_session() -> anyhow::Result<()> {
+async fn test_restarting_p2p_session_tcp() -> anyhow::Result<()> {
     let wrapper = init_test_server().await?;
 
     let client1 = ClientBuilder::from_url(wrapper.url())
@@ -44,7 +44,7 @@ async fn test_restarting_p2p_session() -> anyhow::Result<()> {
     println!("Waiting for session cleanup.");
 
     // Wait expiration timeout + ping timeout + 1s margin
-    tokio::time::delay_for(Duration::from_secs(6)).await;
+    tokio::time::delay_for(Duration::from_secs(15)).await;
 
     println!("Starting Client2");
 
@@ -59,11 +59,11 @@ async fn test_restarting_p2p_session() -> anyhow::Result<()> {
 
     let marker2 = spawn_receive_for_client(&client2, "Client2").await?;
 
-    let _keep = check_forwarding(&client2, &client1, marker1.clone(), Mode::Reliable)
+    let _keep = check_forwarding(&client1, &client2, marker2.clone(), Mode::Reliable)
         .await
         .unwrap();
 
-    let _keep = check_forwarding(&client1, &client2, marker2.clone(), Mode::Reliable)
+    let _keep = check_forwarding(&client2, &client1, marker1.clone(), Mode::Reliable)
         .await
         .unwrap();
 

--- a/server/tests/test_forwarding.rs
+++ b/server/tests/test_forwarding.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 use ya_relay_client::client::Forwarded;
+use ya_relay_client::testing::forwarding_utils::spawn_receive;
 use ya_relay_client::{Client, ClientBuilder};
 use ya_relay_server::testing::server::{init_test_server, ServerWrapper};
 
@@ -20,26 +21,6 @@ async fn hack_make_ip_private(wrapper: &ServerWrapper, client: &Client) {
     // Server won't return any endpoints, so Client won't try to connect directly.
     info.info.endpoints = vec![];
     state.nodes.register(info)
-}
-
-fn spawn_receive<T: std::fmt::Debug + 'static>(
-    label: &'static str,
-    received: Rc<AtomicBool>,
-    rx: mpsc::UnboundedReceiver<T>,
-) {
-    tokio::task::spawn_local({
-        let received = received.clone();
-        async move {
-            rx.for_each(|item| {
-                let received = received.clone();
-                async move {
-                    println!("{} received {:?}", label, item);
-                    received.clone().store(true, SeqCst)
-                }
-            })
-            .await;
-        }
-    });
 }
 
 #[serial_test::serial]

--- a/server/tests/test_init_session.rs
+++ b/server/tests/test_init_session.rs
@@ -22,7 +22,6 @@ async fn test_query_self_node_info() -> anyhow::Result<()> {
     }];
 
     let session = client.sessions.server_session().await.unwrap();
-    let result_endpoints = session.register_endpoints(vec![]).await.unwrap();
     let node_info = session.find_node(node_id).await.unwrap();
 
     // TODO: More checks, after everything will be implemented.
@@ -30,10 +29,6 @@ async fn test_query_self_node_info() -> anyhow::Result<()> {
     assert_ne!(node_info.slot, u32::MAX);
     assert_eq!(node_info.endpoints.len(), 1);
     assert_eq!(node_info.endpoints[0], endpoints[0]);
-
-    // Check server response.
-    assert_eq!(result_endpoints.len(), 1);
-    assert_eq!(result_endpoints[0], endpoints[0]);
 
     Ok(())
 }

--- a/server/tests/test_init_session.rs
+++ b/server/tests/test_init_session.rs
@@ -1,10 +1,8 @@
 use std::convert::{TryFrom, TryInto};
-use std::time::Duration;
 
 use ya_relay_client::testing::Session;
 use ya_relay_client::ClientBuilder;
 use ya_relay_core::session::SessionId;
-use ya_relay_core::{SESSION_CLEANER_INTERVAL, SESSION_TIMEOUT};
 use ya_relay_proto::proto;
 use ya_relay_server::testing::server::init_test_server;
 
@@ -91,32 +89,5 @@ async fn test_query_other_node_info() -> anyhow::Result<()> {
 
     assert_eq!(node1_id, (&node1_info.node_id).try_into().unwrap());
     assert_eq!(node2_id, (&node2_info.node_id).try_into().unwrap());
-    Ok(())
-}
-
-#[serial_test::serial]
-#[ignore] // This functionality is not supported yet
-async fn test_restart_server() -> anyhow::Result<()> {
-    let wrapper = init_test_server().await.unwrap();
-    let client = ClientBuilder::from_url(wrapper.server.inner.url.clone())
-        .connect()
-        .build()
-        .await
-        .unwrap();
-    let node_id = client.node_id();
-    let _session = client.sessions.server_session().await?;
-
-    // Abort server
-    drop(wrapper);
-
-    tokio::time::delay_for(
-        Duration::from_secs(*SESSION_TIMEOUT as u64) + *SESSION_CLEANER_INTERVAL,
-    )
-    .await;
-
-    let session = client.sessions.server_session().await?;
-    let result = session.find_node(node_id).await;
-    log::error!("Result: {:?}", result);
-    assert!(result.is_ok());
     Ok(())
 }

--- a/server/tests/test_init_session.rs
+++ b/server/tests/test_init_session.rs
@@ -95,29 +95,6 @@ async fn test_query_other_node_info() -> anyhow::Result<()> {
     Ok(())
 }
 
-// TODO: Make this test work, when we will have implementation of Session restarts.
-// #[serial_test::serial]
-// async fn test_close_session() -> anyhow::Result<()> {
-//     let wrapper = init_test_server().await.unwrap();
-//     let client = ClientBuilder::from_url(wrapper.server.inner.url.clone())
-//         .connect()
-//         .build()
-//         .await
-//         .unwrap();
-//
-//     let node_id = client.node_id();
-//     let session = client.sessions.server_session().await?;
-//     session.find_node(node_id).await?;
-//
-//     let cloned_session = session.clone();
-//     session.close().await;
-//
-//     let result = cloned_session.find_node(node_id).await;
-//     assert!(result.is_err());
-//
-//     Ok(())
-// }
-
 #[serial_test::serial]
 #[ignore] // This functionality is not supported yet
 async fn test_restart_server() -> anyhow::Result<()> {


### PR DESCRIPTION
resolves: https://github.com/golemfactory/ya-relay/issues/64
This PR doesn't solve problems fully


Changes:
- Closing expired p2p sessions
- Setting NodeId as MAC address on Ethernet layer to preserve addresses across 2 client executions
- Fixes to closing connection in Tcp stack
- Make most of the relay server constants configurable
- Server sends `Disconnected` message, when forwarding to expired Node