### PR TITLE
Explicitly typed `NodeId` byte ref

### DIFF
--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -19,7 +19,10 @@ pub fn typed_from_env<T: std::str::FromStr + Copy>(env_key: &str, def_value: T) 
 }
 
 pub fn parse_node_id(id: &[u8]) -> Result<NodeId, BadRequest> {
-    if id.len() != NodeId::default().as_ref().len() {
+    let default_id = NodeId::default();
+    let default_id_bytes: &[u8] = default_id.as_ref();
+
+    if id.len() != default_id_bytes.len() {
         return Err(BadRequest::InvalidNodeId);
     }
     Ok(NodeId::from(id))


### PR DESCRIPTION
`utils::parse_node_id` is susceptible of failing to infer the type of `NodeId::default().as_ref()` :

```
22 |     if id.len() != NodeId::default().as_ref().len() {
   |                    ------------------^^^^^^--
   |                    |                 |
   |                    |                 cannot infer type for type parameter T declared on the trait AsRef
   |                    this method call resolves to &T
   |
   = note: type must be known at this point
```

The described case is common while developing changes to `ya-client` while using `ya-relay` as a dependency (e.g. in `yagna`). This PR fixes the issue by introducing explicit types


