### PR TITLE
use TryFrom &Vec<u8> feature on NodeId

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 ya-relay-stack = { path = "../crates/stack" }
 ya-relay-proto = { path = "../crates/proto" }
 ya-relay-core = { path = "../crates/core" }
-ya-client-model = "0.3"
 
 anyhow = "1.0"
 chrono = "0.4"

--- a/client/examples/client.rs
+++ b/client/examples/client.rs
@@ -1,10 +1,10 @@
 use env_logger;
 use structopt::{clap, StructOpt};
 
-use ya_client_model::NodeId;
 use ya_relay_client::ClientBuilder;
 use ya_relay_core::crypto::FallbackCryptoProvider;
 use ya_relay_core::key::{load_or_generate, Protected};
+use ya_relay_core::NodeId;
 
 #[derive(StructOpt)]
 #[structopt(about = "NET Client")]

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use url::Url;
 
-use ya_client_model::NodeId;
+use ya_relay_core::NodeId;
 use ya_relay_core::crypto::{CryptoProvider, FallbackCryptoProvider, PublicKey};
 use ya_relay_core::error::InternalError;
 use ya_relay_core::utils::parse_udp_url;

--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -11,10 +11,10 @@ use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use url::Url;
 
-use ya_relay_core::NodeId;
 use ya_relay_core::crypto::{CryptoProvider, FallbackCryptoProvider, PublicKey};
 use ya_relay_core::error::InternalError;
 use ya_relay_core::utils::parse_udp_url;
+use ya_relay_core::NodeId;
 use ya_relay_proto::proto::SlotId;
 
 use crate::session_manager::SessionManager;

--- a/client/src/registry.rs
+++ b/client/src/registry.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use ya_client_model::NodeId;
+use ya_relay_core::NodeId;
 use ya_relay_proto::proto::SlotId;
 
 use crate::session::Session;

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -248,9 +248,7 @@ impl StartingSessions {
         with: SocketAddr,
         request: proto::request::Session,
     ) -> anyhow::Result<()> {
-        let node_id: NodeId = (&request.node_id)
-            .try_into()
-            .map_err(|e: &str| anyhow::anyhow!(e))?;
+        let node_id: NodeId = (&request.node_id).try_into()?;
         let session_id = SessionId::generate();
         let (sender, receiver) = mpsc::channel(1);
 

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -10,12 +10,11 @@ use std::time::Duration;
 use crate::dispatch::{Dispatched, Dispatcher};
 use crate::session_manager::SessionManager;
 
-use ya_client_model::NodeId;
 use ya_relay_core::challenge::{self, prepare_challenge_response, CHALLENGE_DIFFICULTY};
 use ya_relay_core::error::{BadRequest, InternalError, ServerResult, Unauthorized};
 use ya_relay_core::session::SessionId;
 use ya_relay_core::udp_stream::OutStream;
-use ya_relay_core::utils::parse_node_id;
+use ya_relay_core::NodeId;
 use ya_relay_proto::proto::{RequestId, SlotId};
 use ya_relay_proto::{codec, proto};
 
@@ -249,7 +248,9 @@ impl StartingSessions {
         with: SocketAddr,
         request: proto::request::Session,
     ) -> anyhow::Result<()> {
-        let node_id = parse_node_id(&request.node_id)?;
+        let node_id: NodeId = (&request.node_id)
+            .try_into()
+            .map_err(|e: &str| anyhow::anyhow!(e))?;
         let session_id = SessionId::generate();
         let (sender, receiver) = mpsc::channel(1);
 
@@ -330,7 +331,9 @@ impl StartingSessions {
         request: proto::request::Session,
         mut rc: mpsc::Receiver<(RequestId, proto::request::Session)>,
     ) -> ServerResult<()> {
-        let node_id = parse_node_id(&request.node_id)?;
+        let node_id = (&request.node_id)
+            .try_into()
+            .map_err(|_| BadRequest::InvalidNodeId)?;
 
         let (packet, raw_challenge) = prepare_challenge_response();
         let challenge = proto::Packet::response(

--- a/client/src/session_manager.rs
+++ b/client/src/session_manager.rs
@@ -392,9 +392,7 @@ impl SessionManager {
             Err(_) => (self.server_session().await?, node.slot),
         };
 
-        let node_id = (&node.node_id)
-            .try_into()
-            .map_err(|e| anyhow!("Error parsing NodeId: {}", e))?;
+        let node_id = (&node.node_id).try_into()?;
         Ok(self.registry.add_node(node_id, session.clone(), slot).await)
     }
 
@@ -402,9 +400,7 @@ impl SessionManager {
         &self,
         packet: &proto::response::Node,
     ) -> anyhow::Result<Arc<Session>> {
-        let node_id = (&packet.node_id)
-            .try_into()
-            .map_err(|e: &str| anyhow::anyhow!(e))?;
+        let node_id = (&packet.node_id).try_into()?;
         if packet.endpoints.is_empty() {
             bail!(
                 "Node [{}] has no public endpoints. Not establishing p2p session",

--- a/client/src/session_manager.rs
+++ b/client/src/session_manager.rs
@@ -10,13 +10,12 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::RwLock;
 
-use ya_client_model::NodeId;
 use ya_relay_core::challenge::{self, prepare_challenge_request, CHALLENGE_DIFFICULTY};
 use ya_relay_core::crypto::CryptoProvider;
 use ya_relay_core::error::Error;
 use ya_relay_core::session::SessionId;
 use ya_relay_core::udp_stream::{udp_bind, OutStream};
-use ya_relay_core::utils::parse_node_id;
+use ya_relay_core::NodeId;
 use ya_relay_proto::codec::PacketKind;
 use ya_relay_proto::proto;
 use ya_relay_proto::proto::{Forward, RequestId, StatusCode};
@@ -393,17 +392,19 @@ impl SessionManager {
             Err(_) => (self.server_session().await?, node.slot),
         };
 
-        Ok(self
-            .registry
-            .add_node(parse_node_id(&node.node_id)?, session.clone(), slot)
-            .await)
+        let node_id = (&node.node_id)
+            .try_into()
+            .map_err(|e| anyhow!("Error parsing NodeId: {}", e))?;
+        Ok(self.registry.add_node(node_id, session.clone(), slot).await)
     }
 
     pub async fn try_direct_session(
         &self,
         packet: &proto::response::Node,
     ) -> anyhow::Result<Arc<Session>> {
-        let node_id = parse_node_id(&packet.node_id)?;
+        let node_id = (&packet.node_id)
+            .try_into()
+            .map_err(|e: &str| anyhow::anyhow!(e))?;
         if packet.endpoints.is_empty() {
             bail!(
                 "Node [{}] has no public endpoints. Not establishing p2p session",

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -8,9 +8,8 @@ use std::net::Ipv6Addr;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use ya_client_model::NodeId;
 use ya_relay_core::crypto::PublicKey;
-use ya_relay_core::utils::parse_node_id;
+use ya_relay_core::NodeId;
 
 use ya_relay_proto::proto::{Forward, Payload, SlotId};
 use ya_relay_stack::interface::{add_iface_address, add_iface_route, default_iface};
@@ -56,7 +55,7 @@ struct TcpLayerState {
 
 impl VirtNode {
     pub fn try_new(id: &[u8], session: Arc<Session>, session_slot: SlotId) -> anyhow::Result<Self> {
-        let id = parse_node_id(id)?;
+        let id = id.into();
         let ip = IpAddress::from(to_ipv6(&id));
         let endpoint = (ip, TCP_BIND_PORT).into();
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,7 +29,9 @@ sha3 = "0.9"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["tcp", "udp", "net", "sync", "macros", "rt-core", "stream", "time"] }
 tokio-util = { version = "0.3", features = ["codec"] }
-ya-client-model = "0.3"
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", branch="mwu/try_from-vec-to-nodeid"}
+# ya-client-model = { path = "../../../ya-client/model" }
+# ya-client-model = "0.3"
 url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,8 +29,11 @@ sha3 = "0.9"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["tcp", "udp", "net", "sync", "macros", "rt-core", "stream", "time"] }
 tokio-util = { version = "0.3", features = ["codec"] }
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", branch="mwu/try_from-vec-to-nodeid"}
+# DEVELOPMENT
+ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "0b6a9a5b24cd1d858fb483f616e0e4df00842955"}
+# DEBUG LOCAL
 # ya-client-model = { path = "../../../ya-client/model" }
+# RELEASED
 # ya-client-model = "0.3"
 url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,8 @@ pub mod session;
 pub mod udp_stream;
 pub mod utils;
 
+pub use ya_client_model::NodeId;
+
 use std::time::Duration;
 use utils::typed_from_env;
 

--- a/crates/core/src/utils.rs
+++ b/crates/core/src/utils.rs
@@ -1,8 +1,5 @@
 use anyhow::Context;
-
-use crate::error::BadRequest;
 pub use url::Url;
-use ya_client_model::NodeId;
 
 pub fn parse_udp_url(url: &Url) -> anyhow::Result<String> {
     let host = url.host_str().context("Needs host for NET URL")?;
@@ -16,14 +13,4 @@ pub fn typed_from_env<T: std::str::FromStr + Copy>(env_key: &str, def_value: T) 
     std::env::var(env_key)
         .map(|s| s.parse::<T>().unwrap_or(def_value))
         .unwrap_or(def_value)
-}
-
-pub fn parse_node_id(id: &[u8]) -> Result<NodeId, BadRequest> {
-    let default_id = NodeId::default();
-    let default_id_bytes: &[u8] = default_id.as_ref();
-
-    if id.len() != default_id_bytes.len() {
-        return Err(BadRequest::InvalidNodeId);
-    }
-    Ok(NodeId::from(id))
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,7 +19,6 @@ ya-relay-stack = { path = "../crates/stack" }
 ya-relay-proto = { path = "../crates/proto" }
 ya-relay-core = { path = "../crates/core" }
 ya-relay-client = { path = "../client" }
-ya-client-model = "0.3"
 
 actix-rt = "1.1"
 anyhow = "1.0"

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -6,7 +6,7 @@ use std::ops::Sub;
 use crate::error::{InternalError, ServerResult, Unauthorized};
 use ya_relay_core::session::{NodeSession, SessionId};
 
-use ya_client_model::NodeId;
+use ya_relay_core::NodeId;
 
 pub struct NodesState {
     /// Constant time access using slot id optimized for forwarding.
@@ -181,7 +181,7 @@ pub fn hamming_distance(id1: NodeId, id2: NodeId) -> u32 {
 mod tests {
     use crate::state::hamming_distance;
     use std::str::FromStr;
-    use ya_client_model::NodeId;
+    use ya_relay_core::NodeId;
 
     #[test]
     fn test_hamming() {

--- a/server/tests/test_init_session.rs
+++ b/server/tests/test_init_session.rs
@@ -1,7 +1,6 @@
-use std::convert::TryFrom;
+use std::convert::{TryFrom, TryInto};
 use std::time::Duration;
 
-use ya_client_model::NodeId;
 use ya_relay_client::testing::Session;
 use ya_relay_client::ClientBuilder;
 use ya_relay_core::session::SessionId;
@@ -29,7 +28,7 @@ async fn test_query_self_node_info() -> anyhow::Result<()> {
     let node_info = session.find_node(node_id).await.unwrap();
 
     // TODO: More checks, after everything will be implemented.
-    assert_eq!(node_id, NodeId::from(&node_info.node_id[..]));
+    assert_eq!(node_id, (&node_info.node_id).try_into().unwrap());
     assert_ne!(node_info.slot, u32::MAX);
     assert_eq!(node_info.endpoints.len(), 1);
     assert_eq!(node_info.endpoints[0], endpoints[0]);
@@ -90,8 +89,8 @@ async fn test_query_other_node_info() -> anyhow::Result<()> {
     let node2_info = session1.find_node(node2_id).await.unwrap();
     let node1_info = session2.find_node(node1_id).await.unwrap();
 
-    assert_eq!(node1_id, NodeId::from(&node1_info.node_id[..]));
-    assert_eq!(node2_id, NodeId::from(&node2_info.node_id[..]));
+    assert_eq!(node1_id, (&node1_info.node_id).try_into().unwrap());
+    assert_eq!(node2_id, (&node2_info.node_id).try_into().unwrap());
     Ok(())
 }
 


### PR DESCRIPTION
~~**Requires https://github.com/golemfactory/ya-client/pull/117 to be merged first!**~~ 👍 

- grouped imports of ya-client-model into `crates/core`, no accidental wrong versions
- export NodeId from the core crate
- removed `parse_node_id`
- added `TryFrom<&Vec<u8>> for NodeId` in ya-client