### PR TITLE
checking if p2p_connection exists

### DIFF
--- a/client/src/session_manager.rs
+++ b/client/src/session_manager.rs
@@ -757,6 +757,10 @@ impl SessionManager {
         // Note: computing starts here, not after awaiting.
         challenge::solve_blocking(request.challenge, request.difficulty, crypto)
     }
+
+    pub async fn has_p2p_connection(self, node_id: NodeId) -> bool {
+        self.state.read().await.p2p_sessions.get(&node_id).is_some()
+    }
 }
 
 impl Handler for SessionManager {


### PR DESCRIPTION
This PR consists of new function for checking if p2p connection exists for given `NodeId`. The function is used in `yagna` for hybrid net metrics implementation (this is related to issue https://github.com/golemfactory/yagna/issues/1796). Please merge this PR before merging [that ](https://github.com/golemfactory/yagna/pull/1835) one.