### PR TITLE
Disconnect on shutdown

### DIFF
--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -157,6 +157,20 @@ impl Session {
         self.dispatcher.last_seen()
     }
 
+    pub async fn disconnect(&self) -> anyhow::Result<()> {
+        // Don't use temporary session, because we don't want to initialize session
+        // with this address, nor receive the response.
+        let control_packet = proto::Packet::control(
+            self.id.to_vec(),
+            ya_relay_proto::proto::control::Disconnected {
+                by: Some(proto::control::disconnected::By::SessionId(
+                    self.id.to_vec(),
+                )),
+            },
+        );
+        session.send(control_packet).await
+    }
+
     /// Will send `Disconnect` message to other Node, to close end Session
     /// more gracefully.  
     pub async fn close(&self) -> anyhow::Result<()> {

--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -168,14 +168,13 @@ impl Session {
                 )),
             },
         );
-        session.send(control_packet).await
+        self.send(control_packet).await
     }
 
     /// Will send `Disconnect` message to other Node, to close end Session
     /// more gracefully.  
     pub async fn close(&self) -> anyhow::Result<()> {
-        // TODO: Send Disconnect message.
-        Ok(())
+        self.disconnect().await
     }
 }
 

--- a/client/src/session_manager.rs
+++ b/client/src/session_manager.rs
@@ -718,15 +718,7 @@ impl SessionManager {
         // Don't use temporary session, because we don't want to initialize session
         // with this address, nor receive the response.
         let session = Session::new(addr, session_id, self.out_stream()?);
-        let control_packet = proto::Packet::control(
-            session.id.to_vec(),
-            ya_relay_proto::proto::control::Disconnected {
-                by: Some(proto::control::disconnected::By::SessionId(
-                    session.id.to_vec(),
-                )),
-            },
-        );
-        session.send(control_packet).await
+        session.disconnect().await
     }
 
     pub(crate) async fn error_response(

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -47,6 +47,8 @@ pub enum BadRequest {
     DecodingFailed,
     #[error("Invalid Challenge. Error: {0}")]
     InvalidChallenge(String),
+    #[error("Invalid Parameter: {0}")]
+    InvalidParam(String),
 }
 
 #[derive(thiserror::Error, Clone, Debug)]

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -242,7 +242,7 @@ impl Server {
         packet: proto::Control,
         from: SocketAddr,
     ) -> ServerResult<()> {
-        log::info!("Control packet from: {}", from);
+        log::debug!("Control packet from: {}. Packet: {:?}", from, packet);
 
         if let proto::Control {
             kind: Some(proto::control::Kind::Disconnected(Disconnected { by: Some(by) })),
@@ -252,7 +252,14 @@ impl Server {
             match by {
                 By::SessionId(_id) => match server.nodes.get_by_session(session) {
                     None => return Err(Unauthorized::SessionNotFound(session).into()),
-                    Some(node) => server.nodes.remove_session(node.info.slot),
+                    Some(node) => {
+                        log::info!(
+                            "Received Disconnected message from Node [{}]({}).",
+                            node.info.node_id,
+                            from
+                        );
+                        server.nodes.remove_session(node.info.slot)
+                    }
                 },
                 // Allowing only closing sessions. Otherwise we could close someone's else session.
                 By::Slot(_) => {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -24,6 +24,8 @@ use ya_relay_core::session::{NodeInfo, NodeSession, SessionId};
 use ya_relay_core::udp_stream::{udp_bind, InStream, OutStream};
 use ya_relay_proto::codec::PacketKind;
 use ya_relay_proto::proto;
+use ya_relay_proto::proto::control::disconnected::By;
+use ya_relay_proto::proto::control::Disconnected;
 use ya_relay_proto::proto::request::Kind;
 use ya_relay_proto::proto::{RequestId, StatusCode};
 
@@ -108,8 +110,8 @@ impl Server {
                             node.info.node_id,
                         );
                     }
-                    Some(proto::packet::Kind::Control(_control)) => {
-                        log::info!("Control packet from: {}", from);
+                    Some(proto::packet::Kind::Control(packet)) => {
+                        self.control(id, packet, from).await?
                     }
                     _ => log::info!("Packet kind: None from: {}", from),
                 }
@@ -231,6 +233,40 @@ impl Server {
         self.send_to(PacketKind::Forward(packet), &dest_node.address)
             .await
             .map_err(|_| InternalError::Send)?;
+        Ok(())
+    }
+
+    async fn control(
+        &self,
+        session: SessionId,
+        packet: proto::Control,
+        from: SocketAddr,
+    ) -> ServerResult<()> {
+        log::info!("Control packet from: {}", from);
+
+        if let proto::Control {
+            kind: Some(proto::control::Kind::Disconnected(Disconnected { by: Some(by) })),
+        } = packet
+        {
+            let mut server = self.state.write().await;
+            match by {
+                By::SessionId(_id) => match server.nodes.get_by_session(session) {
+                    None => return Err(Unauthorized::SessionNotFound(session).into()),
+                    Some(node) => server.nodes.remove_session(node.info.slot),
+                },
+                // Allowing only closing sessions. Otherwise we could close someone's else session.
+                By::Slot(_) => {
+                    return Err(
+                        BadRequest::InvalidParam("Slot. Only Session allowed".into()).into(),
+                    )
+                }
+                By::NodeId(_) => {
+                    return Err(
+                        BadRequest::InvalidParam("NodeId. Only Session allowed".into()).into(),
+                    )
+                }
+            };
+        }
         Ok(())
     }
 


### PR DESCRIPTION
resolves: https://github.com/golemfactory/ya-relay/issues/66

Don't merge after final decision.
This solution should make disconnections more graceful, but NET should handle cases, when message isn't reaching it's target

Todo:
- [x] Implement shutdown in yagna for NET