### PR TITLE
Strict socket re-binding

### DIFF
--- a/crates/stack/src/socket.rs
+++ b/crates/stack/src/socket.rs
@@ -3,6 +3,7 @@ use smoltcp::socket::*;
 use smoltcp::storage::PacketMetadata;
 use smoltcp::time::Duration;
 use smoltcp::wire::{IpAddress, IpEndpoint, IpProtocol, IpVersion};
+use std::hash::{Hash, Hasher};
 
 use crate::Protocol;
 
@@ -41,6 +42,46 @@ pub enum SocketEndpoint {
     Ip(IpEndpoint),
     Icmp(IcmpEndpoint),
     Other,
+}
+
+impl SocketEndpoint {
+    pub fn is_specified(&self) -> bool {
+        match self {
+            Self::Ip(ip) => ip.is_specified(),
+            Self::Icmp(icmp) => match icmp {
+                IcmpEndpoint::Udp(ip) => ip.is_specified(),
+                IcmpEndpoint::Ident(_) => true,
+                IcmpEndpoint::Unspecified => false,
+            },
+            Self::Other => false,
+        }
+    }
+}
+
+impl Hash for SocketEndpoint {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Ip(ip) => {
+                state.write_u8(1);
+                ip.hash(state);
+            }
+            Self::Icmp(icmp) => {
+                state.write_u8(2);
+                match icmp {
+                    IcmpEndpoint::Unspecified => state.write_u8(1),
+                    IcmpEndpoint::Udp(ip) => {
+                        state.write_u8(2);
+                        ip.hash(state);
+                    }
+                    IcmpEndpoint::Ident(id) => {
+                        state.write_u8(3);
+                        id.hash(state);
+                    }
+                }
+            }
+            Self::Other => state.write_u8(3),
+        }
+    }
 }
 
 impl PartialEq<IpEndpoint> for SocketEndpoint {

--- a/crates/stack/src/socket.rs
+++ b/crates/stack/src/socket.rs
@@ -48,16 +48,13 @@ impl SocketEndpoint {
     pub fn is_specified(&self) -> bool {
         match self {
             Self::Ip(ip) => ip.is_specified(),
-            Self::Icmp(icmp) => match icmp {
-                IcmpEndpoint::Udp(ip) => ip.is_specified(),
-                IcmpEndpoint::Ident(_) => true,
-                IcmpEndpoint::Unspecified => false,
-            },
+            Self::Icmp(icmp) => icmp.is_specified(),
             Self::Other => false,
         }
     }
 }
 
+#[allow(clippy::derive_hash_xor_eq)]
 impl Hash for SocketEndpoint {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {


### PR DESCRIPTION
When a remote peer connects to a local listening socket, that listening socket is moved to another (connected) state. Logic inside the network module is responsible for re-creating the listening socket. This PR fixes a situation where such socket was not properly re-bound, resulting in stalled transmission / no possibility to establish new connections