### PR TITLE
Published ya-relay on crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ lto = "thin"
 [patch.crates-io]
 ya-relay-stack = { path = "crates/stack" }
 ya-relay-proto = { path = "crates/proto" }
+ya-relay-core = { path = "crates/core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ lto = "thin"
 opt-level = 3
 lto = "thin"
 
+[patch.crates-io]
+ya-relay-stack = { path = "crates/stack" }
+ya-relay-proto = { path = "crates/proto" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 
 [dependencies]
-ya-relay-stack = { path = "../crates/stack" }
-ya-relay-proto = { path = "../crates/proto" }
-ya-relay-core = { path = "../crates/core" }
+ya-relay-stack = "0.3"
+ya-relay-proto = "0.3"
+ya-relay-core = "0.2"
 
 anyhow = "1.0"
 chrono = "0.4"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-client"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "ya-relay-client"
-version = "0.2.0"
+version = "0.1.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
+license = "LGPL-3.0"
+description= "Client for hybrid Net communication protocol"
 
 [dependencies]
 ya-relay-stack = "0.3"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -10,8 +10,10 @@ description= "Golem relay base functionality"
 
 
 [dependencies]
-ya-relay-stack = { path = "../stack" }
-ya-relay-proto = { path = "../proto" }
+ya-relay-stack = "0.3"
+ya-relay-proto = "0.2"
+
+ya-client-model = "0.4"
 
 anyhow = "1.0"
 chrono = "0.4"
@@ -29,15 +31,13 @@ sha3 = "0.9"
 thiserror = "1.0"
 tokio = { version = "0.2", features = ["tcp", "udp", "net", "sync", "macros", "rt-core", "stream", "time"] }
 tokio-util = { version = "0.3", features = ["codec"] }
-# DEVELOPMENT
-ya-client-model = { git = "https://github.com/golemfactory/ya-client.git", rev = "0b6a9a5b24cd1d858fb483f616e0e4df00842955"}
-# DEBUG LOCAL
-# ya-client-model = { path = "../../../ya-client/model" }
-# RELEASED
-# ya-client-model = "0.3"
 url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }
 
 [dev-dependencies]
 actix-rt = "1.1"
 env_logger = { version = "0.8", default-features = false }
+
+[patch.crates-io]
+ya-relay-stack = { path = "../stack" }
+ya-relay-proto = { path = "../proto" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "1.0"
 sha2 = "0.9"
 sha3 = "0.9"
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["tcp", "udp", "net", "sync", "macros", "rt-core", "stream", "time"] }
+tokio = { version = "0.2", features = ["tcp", "udp", "net", "sync", "macros", "rt-core", "stream", "time", "blocking"] }
 tokio-util = { version = "0.3", features = ["codec"] }
 url = "2.1"
 uuid = { version = "0.8", features = ["v4"] }
@@ -37,7 +37,3 @@ uuid = { version = "0.8", features = ["v4"] }
 [dev-dependencies]
 actix-rt = "1.1"
 env_logger = { version = "0.8", default-features = false }
-
-[patch.crates-io]
-ya-relay-stack = { path = "../stack" }
-ya-relay-proto = { path = "../proto" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,7 +11,7 @@ description= "Golem relay base functionality"
 
 [dependencies]
 ya-relay-stack = "0.3"
-ya-relay-proto = "0.2"
+ya-relay-proto = "0.3"
 
 ya-client-model = "0.4"
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-core"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-relay/crates/core"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-proto"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-relay/crates/proto"

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-proto"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-relay/crates/proto"

--- a/crates/stack/Cargo.toml
+++ b/crates/stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-stack"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-relay/crates/stack"

--- a/crates/stack/Cargo.toml
+++ b/crates/stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-stack"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-relay/crates/stack"


### PR DESCRIPTION
[ya-relay-client ](https://crates.io/crates/ya-relay-client)v0.2.0 
[ya-relay-core ](https://crates.io/crates/ya-relay-core)v0.2.0 
[ya-relay-proto ](https://crates.io/crates/ya-relay-proto)v0.3.0 
[ya-relay-stack ](https://crates.io/crates/ya-relay-stack)v0.3.0 

It fixes https://github.com/golemfactory/ya-relay/issues/50 

