### PR TITLE
Log session cleanup completion

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -431,7 +431,7 @@ impl Server {
         from: SocketAddr,
         params: proto::request::ReverseConnection,
     ) -> ServerResult<()> {
-        let source_node_info = match { self.state.read().await }.nodes.get_by_session(session_id) {
+        let source_node_info = match { self.state.read().await.nodes.get_by_session(session_id) } {
             None => return Err(Unauthorized::SessionNotFound(session_id).into()),
             Some(node_id) => node_id.info,
         };
@@ -443,10 +443,7 @@ impl Server {
             .try_into()
             .map_err(|_| BadRequest::InvalidNodeId)?;
         let target_session = {
-            match { self.state.read().await }
-                .nodes
-                .get_by_node_id(target_node_id)
-            {
+            match { self.state.read().await.nodes.get_by_node_id(target_node_id) } {
                 None => {
                     return Err(InternalError::Generic(format!(
                         "There is no session with node_id {}",
@@ -757,6 +754,7 @@ impl Server {
             let s = self.clone();
             log::trace!("Cleaning up abandoned sessions");
             s.check_session_timeouts().await;
+            log::trace!("Session cleanup complete");
         }
     }
 


### PR DESCRIPTION
For server debugging purposes.

Additionally, unify state read lock acquisition in server.

