### PR TITLE
Export session descriptor struct

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -17,4 +17,4 @@ pub use ya_relay_stack::*;
 
 // TODO: Exposed for ya-relay-server. Should be made private after we merge implementations.
 pub use dispatch::{dispatch, Dispatcher, Handler};
-pub use session::Session;
+pub use session::{Session, SessionDesc};


### PR DESCRIPTION
A collection of `SessionDesc` is returned by `Client.sessions`, but the type itself is not exported by the `ya-relay-client` module