### PR TITLE
Fix IP4 packet peek for fragmented packets

### DIFF
--- a/crates/stack/src/packet.rs
+++ b/crates/stack/src/packet.rs
@@ -263,7 +263,7 @@ impl<'a> PeekPacket<'a> for IpV4Packet<'a> {
         let len = ntoh_u16(&data[IpV4Field::TOTAL_LEN]).unwrap() as usize;
         let payload_off = Self::read_header_len(data);
 
-        if data_len < len || len < payload_off {
+        if len < payload_off {
             return Err(Error::PacketMalformed("IPv4: payload too short".into()));
         }
         Ok(())


### PR DESCRIPTION
The check is not mandatory and does not account packet fragmentation in