### PR TITLE
Major optimizations

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -450,7 +450,7 @@ impl ClientBuilder {
                 .unwrap_or_else(|| Duration::from_secs(25)),
             tcp_config: NetworkConfig {
                 max_transmission_unit: mtu,
-                buffer_size_multiplier: self.vtcp_buffer_size.unwrap_or(32),
+                buffer_size_multiplier: self.vtcp_buffer_size.unwrap_or(96),
             },
             pcap_path,
             ping_measure_interval: Duration::from_secs(300),

--- a/client/src/session_manager.rs
+++ b/client/src/session_manager.rs
@@ -1263,16 +1263,17 @@ impl Handler for SessionManager {
                 }
             };
 
-            {
-                let mut cache = myself.volatile_cache.borrow_mut();
-                cache.insert((from, reliable), Instant::now() + Duration::from_millis(500));
-            }
-
             if reliable {
                 myself.virtual_tcp.receive(node, forward.payload).await;
             } else {
                 myself.dispatch_unreliable(node.id, forward).await;
             }
+
+            {
+                let mut cache = myself.volatile_cache.borrow_mut();
+                cache.insert((from, reliable), Instant::now() + Duration::from_millis(500));
+            }
+
             anyhow::Result::<()>::Ok(())
         }
         .map_err(|e| log::error!("On forward error: {}", e))

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -221,6 +221,12 @@ impl TcpLayer {
         self.net.poll();
     }
 
+    #[inline]
+    pub fn receive_inject(&self, payload: Payload) {
+        self.net.receive(payload.into_vec());
+        self.net.poll();
+    }
+
     pub async fn shutdown(&self) {
         // empty
     }

--- a/client/src/virtual_layer.rs
+++ b/client/src/virtual_layer.rs
@@ -213,16 +213,13 @@ impl TcpLayer {
                 "[VirtualTcp] Incoming message from new Node [{}]. Adding connection.",
                 node.id
             );
-
             self.add_virt_node(node).await.ok();
         }
-
-        self.net.receive(payload.into_vec());
-        self.net.poll();
+        self.inject(payload);
     }
 
     #[inline]
-    pub fn receive_inject(&self, payload: Payload) {
+    pub fn inject(&self, payload: Payload) {
         self.net.receive(payload.into_vec());
         self.net.poll();
     }

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -84,11 +84,13 @@ impl Forward {
         buf.extend_from_slice(&self.slot.to_be_bytes());
         buf.extend_from_slice(&self.flags.to_be_bytes());
 
-        match self.payload {
-            Payload::BytesMut(b) => buf.extend(b),
-            Payload::Bytes(b) => buf.extend(b),
-            Payload::Vec(b) => buf.extend(b),
-        }
+        let slice = match &self.payload {
+            Payload::BytesMut(b) => b.as_ref(),
+            Payload::Bytes(b) => b.as_ref(),
+            Payload::Vec(b) => b.as_slice(),
+        };
+
+        buf.extend_from_slice(slice);
     }
 
     pub fn decode(mut buf: BytesMut) -> Result<Self, DecodeError> {

--- a/crates/stack/src/connection.rs
+++ b/crates/stack/src/connection.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::convert::TryFrom;
 use std::future::Future;
+use std::net::SocketAddr;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::{Context, Poll};
@@ -82,6 +83,11 @@ impl ConnectionMeta {
             remote,
         }
     }
+
+    #[inline]
+    pub fn to_socket_addr(&self) -> SocketAddr {
+        SocketAddr::from((self.local.addr, self.local.port))
+    }
 }
 
 impl From<ConnectionMeta> for SocketDesc {
@@ -91,6 +97,12 @@ impl From<ConnectionMeta> for SocketDesc {
             local: c.local.into(),
             remote: c.remote.into(),
         }
+    }
+}
+
+impl<'a> From<&'a ConnectionMeta> for SocketEndpoint {
+    fn from(c: &'a ConnectionMeta) -> Self {
+        SocketEndpoint::Ip(c.local)
     }
 }
 

--- a/crates/stack/src/network.rs
+++ b/crates/stack/src/network.rs
@@ -636,7 +636,7 @@ impl Default for StackPollerStrategy {
 }
 
 impl StackPollerStrategy {
-    const MIN_INTERVAL: Duration = Duration::from_millis(10);
+    const MIN_INTERVAL: Duration = Duration::from_micros(1);
     const DEFAULT_INTERVAL: Duration = Duration::from_millis(750);
     const DEFAULT_FACTOR: u8 = 2;
 

--- a/crates/stack/src/socket.rs
+++ b/crates/stack/src/socket.rs
@@ -92,6 +92,7 @@ pub enum SocketEndpoint {
 }
 
 impl SocketEndpoint {
+    #[inline]
     pub fn ip_endpoint(&self) -> Result<IpEndpoint, Error> {
         match self {
             SocketEndpoint::Ip(endpoint) => Ok(*endpoint),
@@ -99,6 +100,7 @@ impl SocketEndpoint {
         }
     }
 
+    #[inline]
     pub fn is_specified(&self) -> bool {
         match self {
             Self::Ip(ip) => ip.is_specified(),

--- a/crates/stack/src/stack.rs
+++ b/crates/stack/src/stack.rs
@@ -254,11 +254,13 @@ impl<'a> Stack<'a> {
         Send::new(data.into(), conn, self.iface.clone(), f)
     }
 
+    #[inline]
     pub fn receive<B: Into<Vec<u8>>>(&self, data: B) {
         let mut iface = self.iface.borrow_mut();
         iface.device_mut().phy_rx(data.into());
     }
 
+    #[inline]
     pub fn poll(&self) -> Result<()> {
         let mut iface = self.iface.borrow_mut();
         iface

--- a/server/src/public_endpoints.rs
+++ b/server/src/public_endpoints.rs
@@ -93,7 +93,7 @@ impl EndpointsChecker {
         Ok(endpoints)
     }
 
-    fn incorrect_packet(packet_type: &str, from: SocketAddr) -> LocalBoxFuture<()> {
+    fn incorrect_packet(packet_type: &str, from: SocketAddr) {
         log::warn!(
             "{} packet received on Socket for discovering endpoints (from {}). \
             Correct client implementation shouldn't send this. This could be either bug \
@@ -101,7 +101,6 @@ impl EndpointsChecker {
             packet_type,
             from,
         );
-        Box::pin(futures::future::ready(()))
     }
 }
 
@@ -126,8 +125,9 @@ impl Handler for EndpointsChecker {
         _session_id: Vec<u8>,
         _control: proto::Control,
         from: SocketAddr,
-    ) -> LocalBoxFuture<'static, ()> {
-        Self::incorrect_packet("Control", from)
+    ) -> Option<LocalBoxFuture<'static, ()>> {
+        Self::incorrect_packet("Control", from);
+        None
     }
 
     #[inline]
@@ -136,12 +136,18 @@ impl Handler for EndpointsChecker {
         _session_id: Vec<u8>,
         _request: proto::Request,
         from: SocketAddr,
-    ) -> LocalBoxFuture<'static, ()> {
-        Self::incorrect_packet("Request", from)
+    ) -> Option<LocalBoxFuture<'static, ()>> {
+        Self::incorrect_packet("Request", from);
+        None
     }
 
     #[inline]
-    fn on_forward(self, _forward: proto::Forward, from: SocketAddr) -> LocalBoxFuture<'static, ()> {
-        Self::incorrect_packet("Forward", from)
+    fn on_forward(
+        self,
+        _forward: proto::Forward,
+        from: SocketAddr,
+    ) -> Option<LocalBoxFuture<'static, ()>> {
+        Self::incorrect_packet("Forward", from);
+        None
     }
 }


### PR DESCRIPTION
The heart of this PR is the `udp_stream` optimization which applies to both client and server.

- fixed `udp_stream` buffer resize bottleneck
- virtual TCP socket buffer size increased x3
- "fast lane" for forwarding TCP packets to already resolved nodes
  - cache is reset on disconnection with the relay server
- optimized `Forward::encode`
- **increased** default `StackPollerStrategy` intervals