### PR TITLE
Server: return unauthorized if session is not known

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -33,8 +33,6 @@ pub enum Undefined {}
 
 #[derive(thiserror::Error, Clone, Debug)]
 pub enum BadRequest {
-    #[error("Session [{0}] not found.")]
-    SessionNotFound(SessionId),
     #[error("No SessionId.")]
     NoSessionId,
     #[error("Invalid NodeId.")]


### PR DESCRIPTION
Clients receiving the Unauthorized error will try to re-initiate server sessions

- allow `Disconnected` messages for unknown sessions
- remove `BadRequest::SessionNotFound` variant
