### PR TITLE
ignore ResumeForwarding control packet when dispatching

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -83,10 +83,13 @@ impl Server {
                             Some(proto::packet::Kind::Request(request)) => {
                                 self.clone().establish_session(id, from, request).await
                             }
-                            Some(proto::packet::Kind::Control(proto::Control {
-                                kind: Some(proto::control::Kind::Disconnected { .. }),
-                                ..
-                            })) => Ok(()),
+                            Some(proto::packet::Kind::Control(proto::Control { kind })) => {
+                                match kind {
+                                    Some(proto::control::Kind::Disconnected { .. }) => Ok(()),
+                                    Some(proto::control::Kind::ResumeForwarding { .. }) => Ok(()),
+                                    _ => unknown_session(id),
+                                }
+                            }
                             _ => unknown_session(id),
                         };
                     }


### PR DESCRIPTION
It fixes https://github.com/golemfactory/ya-relay/issues/155