### PR TITLE
Inbound network prerequisites

### DIFF
--- a/crates/stack/src/device.rs
+++ b/crates/stack/src/device.rs
@@ -36,6 +36,7 @@ impl CaptureDevice {
     pub fn tap(mtu: usize) -> Self {
         Self {
             max_transmission_unit: mtu,
+            medium: phy::Medium::Ethernet,
             ..Default::default()
         }
     }

--- a/crates/stack/src/error.rs
+++ b/crates/stack/src/error.rs
@@ -3,7 +3,7 @@ use futures::channel::mpsc::SendError;
 use futures::channel::oneshot::Canceled;
 use std::net::{AddrParseError, IpAddr};
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Clone, Debug)]
 pub enum Error {
     #[error("Invalid IP address: {0}")]
     IpAddr(#[from] AddrParseError),

--- a/crates/stack/src/socket.rs
+++ b/crates/stack/src/socket.rs
@@ -1,4 +1,5 @@
 use std::hash::{Hash, Hasher};
+use std::net::SocketAddr;
 
 use derive_more::From;
 use smoltcp::socket::*;
@@ -170,6 +171,12 @@ impl From<Option<IpEndpoint>> for SocketEndpoint {
             Some(endpoint) => Self::Ip(endpoint),
             None => Self::Other,
         }
+    }
+}
+
+impl From<SocketAddr> for SocketEndpoint {
+    fn from(addr: SocketAddr) -> Self {
+        Self::Ip(addr.into())
     }
 }
 


### PR DESCRIPTION
- cloneable `Error`
- fixes a bug in `ArpPacketMut::set_field` (was unused)
- `impl From<SocketAddr> for SocketEndpoint`