### PR TITLE
Poll the stack while re-binding a socket in `process_ingress`

### DIFF
--- a/crates/stack/src/network.rs
+++ b/crates/stack/src/network.rs
@@ -383,6 +383,7 @@ impl Network {
                 if let Err(e) = self.bind(p, ep) {
                     log::warn!("{}: cannot bind socket {} {:?}: {}", self.name, p, ep, e);
                 }
+                let _ = self.stack.poll();
                 self.process_ingress() + received
             }
             None => received,


### PR DESCRIPTION
Without polling the stack, the bound socket may not enter the `LISTENING` state