### PR TITLE
Export to CSV in `saturate` example

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -30,4 +30,4 @@ humantime = "2.1"
 prettytable-rs = "0.8"
 simple-logging = "2.0"
 structopt = "0.3"
-tokio = { version = "1", features = ["signal"] }
+tokio = { version = "1", features = ["fs", "io-util", "signal"] }


### PR DESCRIPTION
- option for periodically dumping sampled data into a CSV file
- option for running the receiver and sender for a specified amount of time
- customizable csv and log output directory