### PR TITLE
(smoltcp) fix data_range overflow in AssemblerIter

### DIFF
--- a/crates/stack/Cargo.toml
+++ b/crates/stack/Cargo.toml
@@ -17,7 +17,7 @@ managed = { version = "0.8", features = ["std"] }
 num-derive = "0.3"
 num-traits = "0.2"
 rand = { version = "0.8", features = ["std"] }
-smoltcp = "0.8"
+smoltcp = { git = "https://github.com/golemfactory/smoltcp", rev = "acb743b6990fd92303c24c43ff75711422a5cb94" }
 thiserror = "1.0"
 tokio = { version = "1", features = ["time", "rt"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
Includes the change in https://github.com/golemfactory/smoltcp/commit/acb743b6990fd92303c24c43ff75711422a5cb94