### PR TITLE
Remove `Bytes` / `BytesMut` / `Vec<u8>` to `Payload` conversions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ lto = "thin"
 [profile.bench]
 opt-level = 3
 lto = "thin"
+
+[patch.crates-io]
+ya-relay-util = { path = "crates/util" }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-client"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 license = "LGPL-3.0"

--- a/client/examples/saturate.rs
+++ b/client/examples/saturate.rs
@@ -189,7 +189,7 @@ fn send(
                 break;
             }
 
-            if let Err(e) = sender.send(vec![1; chunk_size]).await {
+            if let Err(e) = sender.send(vec![1; chunk_size].into()).await {
                 state.set_err(anyhow!(e)).await;
                 break;
             }

--- a/client/src/session_manager.rs
+++ b/client/src/session_manager.rs
@@ -20,7 +20,7 @@ use ya_relay_core::NodeId;
 use ya_relay_proto::codec::PacketKind;
 use ya_relay_proto::proto;
 use ya_relay_proto::proto::control::disconnected::By;
-use ya_relay_proto::proto::{Forward, RequestId, SlotId, FORWARD_SLOT_ID};
+use ya_relay_proto::proto::{Forward, RequestId, SlotId, FORWARD_SLOT_ID, Payload};
 use ya_relay_stack::{Channel, Connection};
 
 use crate::client::{ClientConfig, ForwardSender, Forwarded};
@@ -670,7 +670,7 @@ impl SessionManager {
         self,
         connection: Connection,
         node: NodeEntry,
-        mut rx: mpsc::Receiver<Vec<u8>>,
+        mut rx: mpsc::Receiver<Payload>,
     ) {
         let pause = node.session.forward_pause.clone();
         let session = node.session.clone();
@@ -710,7 +710,7 @@ impl SessionManager {
         self,
         session: Arc<Session>,
         node: NodeEntry,
-        mut rx: mpsc::Receiver<Vec<u8>>,
+        mut rx: mpsc::Receiver<Payload>,
     ) {
         let pause = node.session.forward_pause.clone();
 
@@ -1113,7 +1113,7 @@ impl SessionManager {
         let payload = Forwarded {
             transport: TransportType::Unreliable,
             node_id,
-            payload: forward.payload.into_vec(),
+            payload: forward.payload,
         };
 
         if tx.send(payload).is_err() {

--- a/client/src/testing/forwarding_utils.rs
+++ b/client/src/testing/forwarding_utils.rs
@@ -79,7 +79,7 @@ pub async fn check_forwarding(
         receiver_client.node_id()
     );
 
-    tx.send(vec![1u8]).await?;
+    tx.send(vec![1u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-proto"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-relay/crates/proto"
@@ -13,6 +13,8 @@ default = ["codec"]
 codec = ["futures", "tokio", "tokio-util", "bytes", "derive_more", "thiserror"]
 
 [dependencies]
+ya-relay-util = { version = "0.1", path = "../util" }
+
 prost = "0.10"
 rand = "0.8"
 

--- a/crates/stack/Cargo.toml
+++ b/crates/stack/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ya-relay-stack"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Golem Factory <contact@golem.network>"]
 edition = "2018"
 homepage = "https://github.com/golemfactory/ya-relay/crates/stack"
@@ -9,6 +9,8 @@ license = "LGPL-3.0"
 description= "Embeddable networking stack"
 
 [dependencies]
+ya-relay-util = { version = "0.1", path = "../util" }
+
 derive_more = "0.99"
 futures = "0.3"
 lazy_static = "1"

--- a/crates/stack/src/stack.rs
+++ b/crates/stack/src/stack.rs
@@ -16,6 +16,8 @@ use crate::socket::*;
 use crate::{port, StackConfig};
 use crate::{Error, Result};
 
+use ya_relay_util::Payload;
+
 #[derive(Clone)]
 pub struct Stack<'a> {
     iface: Rc<RefCell<CaptureInterface<'a>>>,
@@ -242,7 +244,7 @@ impl<'a> Stack<'a> {
     }
 
     #[inline]
-    pub fn send<B: Into<Vec<u8>>, F: Fn() + 'static>(
+    pub fn send<B: Into<Payload>, F: Fn() + 'static>(
         &self,
         data: B,
         conn: Connection,
@@ -252,7 +254,7 @@ impl<'a> Stack<'a> {
     }
 
     #[inline]
-    pub fn receive<B: Into<Vec<u8>>>(&self, data: B) {
+    pub fn receive<B: Into<Payload>>(&self, data: B) {
         let mut iface = self.iface.borrow_mut();
         iface.device_mut().phy_rx(data.into());
     }

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ya-relay-util"
+version = "0.1.0"
+authors = ["Golem Factory <contact@golem.network>"]
+edition = "2018"
+homepage = "https://github.com/golemfactory/ya-relay/crates/util"
+repository = "https://github.com/golemfactory/ya-relay"
+license = "LGPL-3.0"
+description= "Golem relay utils"
+
+[features]
+default = ["payload"]
+payload = ["bytes", "derive_more"]
+
+[dependencies]
+bytes = { version = "1", optional = true }
+derive_more = { version = "0.99", optional = true }

--- a/crates/util/src/lib.rs
+++ b/crates/util/src/lib.rs
@@ -1,0 +1,3 @@
+mod payload;
+
+pub use payload::Payload;

--- a/crates/util/src/payload.rs
+++ b/crates/util/src/payload.rs
@@ -1,0 +1,204 @@
+use std::iter::FromIterator;
+
+use bytes::BytesMut;
+use derive_more::From;
+
+#[derive(Debug, Clone, From)]
+pub enum Payload {
+    BytesMut(BytesMut),
+    Vec(Vec<u8>),
+}
+
+impl Payload {
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::BytesMut(b) => b.len(),
+            Self::Vec(b) => b.len(),
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        match self {
+            Self::BytesMut(b) => b.is_empty(),
+            Self::Vec(b) => b.is_empty(),
+        }
+    }
+
+    #[inline]
+    pub fn reserve(&mut self, additional: usize) {
+        match self {
+            Self::BytesMut(b) => b.reserve(additional),
+            Self::Vec(b) => b.reserve(additional),
+        }
+    }
+
+    pub fn extend(&mut self, bytes: BytesMut) {
+        match std::mem::take(self) {
+            Self::BytesMut(mut b) => {
+                b.extend(bytes);
+                *self = Self::BytesMut(b);
+            }
+            Self::Vec(mut v) => {
+                v.extend(bytes.into_iter());
+                *self = Self::Vec(v);
+            }
+        }
+    }
+
+    pub fn prepend(&mut self, with: &[u8]) {
+        match self {
+            Self::BytesMut(b) => {
+                if with.len() == 0 {
+                    return;
+                } else if b.len() == 0 {
+                    b.extend(with);
+                } else {
+                    let len = with.len();
+                    b.extend(std::iter::repeat(0).take(len));
+
+                    for i in (0 .. b.len()).rev() {
+                        b[i] = if i >= len {
+                            b[i - len]
+                        } else {
+                            with[i]
+                        };
+                    }
+                }
+            },
+            Self::Vec(b) => {
+                b.splice(0..0, with.iter().copied());
+            },
+        }
+    }
+
+    #[inline]
+    pub fn into_vec(self) -> Vec<u8> {
+        match self {
+            Self::BytesMut(b) => Vec::from_iter(b.into_iter()),
+            Self::Vec(b) => b,
+        }
+    }
+
+    #[inline]
+    pub fn into_bytes(self) -> BytesMut {
+        match self {
+            Self::BytesMut(b) => b,
+            Self::Vec(b) => BytesMut::from_iter(b),
+        }
+    }
+}
+
+impl Default for Payload {
+    fn default() -> Self {
+        Self::Vec(Default::default())
+    }
+}
+
+impl From<Box<[u8]>> for Payload {
+    fn from(b: Box<[u8]>) -> Self {
+        Self::Vec(b.into_vec())
+    }
+}
+
+impl AsRef<[u8]> for Payload {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::BytesMut(b) => b.as_ref(),
+            Self::Vec(b) => b.as_slice(),
+        }
+    }
+}
+
+impl AsMut<[u8]> for Payload {
+    #[inline]
+    fn as_mut(&mut self) -> &mut [u8] {
+        match self {
+            Self::BytesMut(b) => b.as_mut(),
+            Self::Vec(b) => b.as_mut(),
+        }
+    }
+}
+
+impl FromIterator<u8> for Payload {
+    fn from_iter<T: IntoIterator<Item = u8>>(iter: T) -> Self {
+        Self::Vec(Vec::from_iter(iter))
+    }
+}
+
+impl PartialEq<Payload> for Payload {
+    fn eq(&self, other: &Payload) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl PartialEq<Payload> for BytesMut {
+    fn eq(&self, other: &Payload) -> bool {
+        self.as_ref() == other.as_ref()
+    }
+}
+
+impl PartialEq<Payload> for Vec<u8> {
+    fn eq(&self, other: &Payload) -> bool {
+        self.as_slice() == other.as_ref()
+    }
+}
+
+impl Eq for Payload {}
+
+impl IntoIterator for Payload {
+    type Item = u8;
+    type IntoIter = IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::BytesMut(b) => IntoIter::BytesMut(b.into_iter()),
+            Self::Vec(v) => IntoIter::Vec(v.into_iter())
+        }
+    }
+}
+
+pub enum IntoIter {
+    BytesMut(bytes::buf::IntoIter<BytesMut>),
+    Vec(std::vec::IntoIter<u8>),
+}
+
+impl Iterator for IntoIter {
+    type Item = u8;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::BytesMut(ref mut i) => i.next(),
+            Self::Vec(ref mut i) => i.next(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::FromIterator;
+    use bytes::BytesMut;
+    use super::Payload;
+
+    #[test]
+    fn test_prepend() {
+        const EMPTY: &[u8] = &[];
+
+        let bytes = BytesMut::from_iter(5..=8u8);
+        let mut payload = Payload::BytesMut(BytesMut::new());
+
+        payload.prepend(EMPTY);
+        assert_eq!(EMPTY, payload.as_ref());
+        payload.prepend(bytes.as_ref());
+        assert_eq!(&[5, 6, 7, 8], payload.as_ref());
+        payload.prepend(EMPTY);
+        assert_eq!(&[5, 6, 7, 8], payload.as_ref());
+        payload.prepend(&[4]);
+        assert_eq!(&[4, 5, 6, 7, 8], payload.as_ref());
+        payload.prepend(&[1, 2, 3]);
+        assert_eq!(&[1, 2, 3, 4, 5, 6, 7, 8], payload.as_ref());
+    }
+}

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -971,7 +971,7 @@ impl Server {
                     log::error!("Packet dispatch timed out (request={request_id:?}, from={addr})");
                 })
             })
-            .buffered(DISPATCH_TASK_COUNT)
+            .buffer_unordered(DISPATCH_TASK_COUNT)
             .for_each(|_| futures::future::ready(()))
             .await;
 

--- a/server/tests/test_discovery.rs
+++ b/server/tests/test_discovery.rs
@@ -56,8 +56,8 @@ async fn test_find_node_by_alias() -> anyhow::Result<()> {
     let mut tx1 = client1.forward_unreliable(alias).await.unwrap();
     let mut tx2 = client2.forward_unreliable(client1.node_id()).await.unwrap();
 
-    tx1.send(vec![1u8]).await?;
-    tx2.send(vec![2u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
+    tx2.send(vec![2u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -106,7 +106,7 @@ async fn test_find_node_by_alias_private_ip() -> anyhow::Result<()> {
     println!("Forwarding: unreliable");
 
     let mut tx1 = client1.forward_unreliable(alias).await.unwrap();
-    tx1.send(vec![1u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(received2.load(SeqCst));
@@ -114,7 +114,7 @@ async fn test_find_node_by_alias_private_ip() -> anyhow::Result<()> {
     received2.store(false, SeqCst);
 
     let mut tx1 = client1.forward_unreliable(client2.node_id()).await.unwrap();
-    tx1.send(vec![1u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     assert!(received2.load(SeqCst));

--- a/server/tests/test_forwarding.rs
+++ b/server/tests/test_forwarding.rs
@@ -54,8 +54,8 @@ async fn test_forward_unreliable() -> anyhow::Result<()> {
     let mut tx1 = client1.forward_unreliable(client2.node_id()).await.unwrap();
     let mut tx2 = client2.forward_unreliable(client1.node_id()).await.unwrap();
 
-    tx1.send(vec![1u8]).await?;
-    tx2.send(vec![2u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
+    tx2.send(vec![2u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -102,8 +102,8 @@ async fn test_forward_reliable() -> anyhow::Result<()> {
     let mut tx1 = client1.forward(client2.node_id()).await.unwrap();
     let mut tx2 = client2.forward(client1.node_id()).await.unwrap();
 
-    tx1.send(vec![1u8]).await?;
-    tx2.send(vec![2u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
+    tx2.send(vec![2u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -148,8 +148,8 @@ async fn test_p2p_unreliable() -> anyhow::Result<()> {
     let mut tx1 = client1.forward_unreliable(client2.node_id()).await.unwrap();
     let mut tx2 = client2.forward_unreliable(client1.node_id()).await.unwrap();
 
-    tx1.send(vec![1u8]).await?;
-    tx2.send(vec![2u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
+    tx2.send(vec![2u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -193,8 +193,8 @@ async fn test_p2p_reliable() -> anyhow::Result<()> {
     let mut tx1 = client1.forward(client2.node_id()).await?;
     let mut tx2 = client2.forward(client1.node_id()).await?;
 
-    tx1.send(vec![1u8]).await?;
-    tx2.send(vec![2u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
+    tx2.send(vec![2u8].into()).await?;
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -254,7 +254,7 @@ async fn test_rate_limiter() -> anyhow::Result<()> {
     let mut send_cnt = 0;
     for i in 0..iterations {
         println!("Send 255. iter: {}", i);
-        tx1.send(big_payload.clone()).await?;
+        tx1.send(big_payload.clone().into()).await?;
         send_cnt += big_payload.len();
     }
     tokio::time::sleep(Duration::from_millis(100)).await;

--- a/server/tests/test_reverse_connection.rs
+++ b/server/tests/test_reverse_connection.rs
@@ -54,7 +54,7 @@ async fn test_reverse_connection() -> anyhow::Result<()> {
     let mut tx1 = client1.forward_unreliable(client2.node_id()).await.unwrap();
     println!("forwarder setup");
 
-    tx1.send(vec![1u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
     println!("message send");
 
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -74,7 +74,7 @@ async fn test_reverse_connection() -> anyhow::Result<()> {
     let mut tx2 = client2.forward_unreliable(client1.node_id()).await.unwrap();
     println!("forwarder setup");
 
-    tx2.send(vec![2u8]).await?;
+    tx2.send(vec![2u8].into()).await?;
     println!("message send");
 
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -126,7 +126,7 @@ async fn test_reverse_connection_fail_both_private() -> anyhow::Result<()> {
     let mut tx1 = client1.forward_unreliable(client2.node_id()).await.unwrap();
     println!("forwarder setup");
 
-    tx1.send(vec![1u8]).await?;
+    tx1.send(vec![1u8].into()).await?;
     println!("message send");
 
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -146,7 +146,7 @@ async fn test_reverse_connection_fail_both_private() -> anyhow::Result<()> {
     let mut tx2 = client2.forward_unreliable(client1.node_id()).await.unwrap();
     println!("forwarder setup");
 
-    tx2.send(vec![2u8]).await?;
+    tx2.send(vec![2u8].into()).await?;
     println!("message send");
     tokio::time::sleep(Duration::from_millis(100)).await;
 


### PR DESCRIPTION
This PR removes unnecessary conversions from `Payload` to `Bytes` / `BytesMut` / `Vec<u8>` (and vice versa) on the whole packet flow path.

Additional changes:
- server: use unordered task dispatching
- client: dispatcher: fetch the dispatcher once in `dispatch`