### PR TITLE
Repeat protocol messages

### DIFF
--- a/client/src/dispatch.rs
+++ b/client/src/dispatch.rs
@@ -57,7 +57,7 @@ where
                                 response.code,
                                 kind,
                             ),
-                            None => log::warn!("Unexpected response from {}: {:?}", from, kind),
+                            None => log::debug!("Unexpected response from {}: {:?}", from, kind),
                         },
                         // TODO: Handle empty packet kind here
                         None => log::debug!("Empty response kind from: {}", from),


### PR DESCRIPTION
1. The client sends the same request up to 4 times in `timeout / 4` intervals.
2. The server ignores duplicate requests, and the client ignores duplicate responses.
3. Tune `DISPATCH_TASK_COUNT` to 32.

Closes https://github.com/golemfactory/yagna/issues/1872.