### PR TITLE
Deduplicate incoming requests in ya-relay-client

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ on:
       - main
       - release/*
 
+env:
+  rust_stable: 1.64.0
+
 jobs:
   build:
     name: Tests
@@ -26,10 +29,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Install last stable Rust
+      - name: Install Rust ${{ env.rust_stable }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ env.rust_stable }}
           components: rustfmt, clippy
 
 #      - name: Install openssl ( Windows only )

--- a/crates/stack/src/stack.rs
+++ b/crates/stack/src/stack.rs
@@ -50,12 +50,12 @@ impl<'a> Stack<'a> {
 
     pub fn add_address(&self, address: IpCidr) {
         let mut iface = self.iface.borrow_mut();
-        add_iface_address(&mut (*iface), address);
+        add_iface_address(&mut iface, address);
     }
 
     pub fn add_route(&self, net_ip: IpCidr, route: Route) {
         let mut iface = self.iface.borrow_mut();
-        add_iface_route(&mut (*iface), net_ip, route);
+        add_iface_route(&mut iface, net_ip, route);
     }
 
     #[inline]


### PR DESCRIPTION
P2P connections might cause clients to send duplicate requests not only to the relay (already handled correctly), but also to other clients. This has caused deadlocks while establishing a reverse connection.