### PR TITLE
Release build fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
 
       - name: Build linux
         run: |
-          cargo build --release --target x86_64-unknown-linux-musl
+          cargo build --release --target x86_64-unknown-linux-musl -p ya-relay-server
       # - name: Pack
       #   id: pack
       #   shell: bash


### PR DESCRIPTION
It resolves this Release build failure https://github.com/golemfactory/ya-relay/actions/runs/6254512421/job/16982209231
(it is caused by converting `ya-relay` to a package)