### PR TITLE
Neighbourhood fix

### DIFF
--- a/client/src/client.rs
+++ b/client/src/client.rs
@@ -432,7 +432,7 @@ impl Client {
             .await
             .map_err(|e| anyhow!("Error establishing session with relay: {e}"))?
             .raw
-            .neighbours(count, false)
+            .neighbours(count, true)
             .await?;
 
         let nodes = neighbours


### PR DESCRIPTION
When requesting neighbourhood information, the client can select if it is interested in the public key of the nodes.
Prior to the 'redesign idea' the server did not return any identity for the nodes when the public key was not requested, the client always requested the public key.
This was 'fixed' during the 'redesign idea' changes so the client does not request the public key and the server send back the identities with empty public key.
Unfortunately this is not backward compatible and the new client does not work with the previous server version (it would work the other way around, new server - previous client) as it gets node information without identities so it is not usable for neighbourhood brodcasting.