### PR TITLE
Recover stale relay sessions after network changes

### DIFF
--- a/client/src/session.rs
+++ b/client/src/session.rs
@@ -795,7 +795,16 @@ impl SessionLayer {
         tokio::task::spawn_local(async move {
             let entry = myself.registry.guard(session.owner.default_id, &[]).await;
 
-            entry.transition(SessionState::Closing).await?;
+            let previous = entry.begin_closing().await;
+            if !matches!(previous, SessionState::Established(_)) {
+                log::warn!(
+                    "Recovering session {} with [{}] ({}) from inconsistent state: {}",
+                    session.raw.id,
+                    session.owner.default_id,
+                    session.raw.remote,
+                    previous
+                );
+            }
             myself.unregister_session(session).await;
             entry.transition(SessionState::Closed).await?;
             Ok(())

--- a/client/src/session/expire.rs
+++ b/client/src/session/expire.rs
@@ -76,6 +76,13 @@ async fn close_sessions(
             session.raw.remote
         );
 
-        layer.close_session(session.clone()).await;
+        if let Err(error) = layer.close_session(session.clone()).await {
+            log::warn!(
+                "Failed to close expired session {} ({}): {}",
+                session.raw.id,
+                session.raw.remote,
+                error
+            );
+        }
     }
 }

--- a/client/src/session/network_view.rs
+++ b/client/src/session/network_view.rs
@@ -275,6 +275,20 @@ pub struct NodeViewState {
 }
 
 impl NodeView {
+    /// Starts closing a registered session even if its state got out of sync with
+    /// the session registry. A registered `DirectSession` is authoritative here:
+    /// leaving it in the registry would make subsequent connection attempts keep
+    /// returning the dead session forever.
+    pub(crate) async fn begin_closing(&self) -> SessionState {
+        let previous = {
+            let mut target = self.state.write().await;
+            std::mem::replace(&mut target.state, SessionState::Closing)
+        };
+
+        self.notify_change(SessionState::Closing);
+        previous
+    }
+
     pub async fn transition(
         &self,
         new_state: SessionState,
@@ -1031,6 +1045,27 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
+    }
+
+    #[actix_rt::test]
+    async fn begin_closing_recovers_inconsistent_session_state() {
+        let network_view = NetworkView::default();
+        let entry = network_view.guard(*NODE_ID1, &[*ADDR1]).await;
+
+        entry
+            .transition_outgoing(InitState::ConnectIntent)
+            .await
+            .unwrap();
+
+        let previous = entry.begin_closing().await;
+        assert!(matches!(
+            previous,
+            SessionState::Outgoing(InitState::ConnectIntent)
+        ));
+        assert!(matches!(entry.state().await, SessionState::Closing));
+
+        entry.transition(SessionState::Closed).await.unwrap();
+        assert!(matches!(entry.state().await, SessionState::Closed));
     }
 
     /// Checks if permits work correctly in case of attempts to initialize


### PR DESCRIPTION
## Summary

- recover registered relay sessions whose state machine is inconsistent
- remove the dead session and notify the server-session keep-alive task with the Closed state
- report failures when expiration cannot close a session
- add a regression test for closing from an inconsistent state

## Problem

After a laptop sleep and network/NAT change, the relay server can expire the old publication while the client keeps the old DirectSession locally. Session expiration repeatedly attempts to close it, but the transition to Closing fails and its result is discarded. Because the registry never reaches Closed or FailedEstablish, the server-session keep-alive task does not reconnect and the node is not published again.

## Tests

- cargo test -p ya-relay-client
- 15 unit tests passed
- 2 doc-tests passed